### PR TITLE
DOCS-10634 - Fixing hostname tip for Compass connect

### DIFF
--- a/source/includes/steps-starting-compass.yaml
+++ b/source/includes/steps-starting-compass.yaml
@@ -19,9 +19,13 @@ content: |
 
            .. tip::
 
-              If you enter a MongoDB connection string in this field, Compass
-              automatically parses the string to populate relevant fields in
-              this dialog.
+              Starting with version 1.8.0, MongoDB Compass can detect 
+              whether you have a MongoDB 
+              :manual:`URI connection string </reference/connection-string>` 
+              in your system clipboard and auto-populate the connection
+              dialog from the URI. Open MongoDB Compass with a URI 
+              connection string in your clipboard and click :guilabel:`Yes`
+              when prompted to auto-populate the dialog.
 
        * - :guilabel:`Port`
          - The port on which ``mongod`` is running.


### PR DESCRIPTION
Hostname tip for Compass connect was inaccurate - Fixing it up with accurate info.  After code review, version info was added.

CodeReview: https://mongodbcr.appspot.com/149550001/

Staging: https://docs-mongodbcom-staging.corp.mongodb.com/compass/jeffreyallen/DOCS-10634/connect.html