### PR TITLE
DOCSP-624 - Updating query bar to reflect BSON supported types

### DIFF
--- a/source/query-bar.txt
+++ b/source/query-bar.txt
@@ -62,13 +62,17 @@ The Compass :guilabel:`Filter` supports using the :program:`mongo`
 shell mode representation of the MongoDB Extended JSON `BSON data types
 <https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson-data-types-and-associated-representations>`_.
 
-For example, the following filter example will display documents with a
-``start_date`` field of ``2017-05-01 00:00:00.000`` provided that the
-value of ``start_date`` is specified as type ``Date``:
+For example, The following filter returns documents where
+``start_date`` is chronologically later than the BSON ``Date``
+``2017-05-01``:
 
 .. code-block:: javascript
 
-   { "start_date": new Date('2017-05-01 00:00:00.000') }
+   { "start_date": {$gt: new Date ('2017-05-01')} }
+
+Without the ``Date`` type specified in the filter, Compass would
+perform the ``greater than`` comparison using strings instead of
+comparing the ``Date`` values chronologically.
 
 To specify an `ObjectID <https://docs.mongodb.com/manual/reference/method/ObjectId/>`_,
 use the format ``ObjectId('<id>')``, as in the following filter example:

--- a/source/query-bar.txt
+++ b/source/query-bar.txt
@@ -62,23 +62,28 @@ The Compass :guilabel:`Filter` supports using the :program:`mongo`
 shell mode representation of the MongoDB Extended JSON `BSON data types
 <https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson-data-types-and-associated-representations>`_.
 
-For example, the following filter returns documents where
-``start_date`` is greater than than the BSON ``Date``
-``2017-05-01``:
+For example, consider a field ``start_date`` that stores dates using the
+``Date`` `BSON type
+<https://docs.mongodb.com/manual/reference/bson-types/#bson-types>`_.
+
+The following filter returns documents where ``start_date`` is
+`greater than <https://docs.mongodb.com/manual/reference/operator/query/gt/>`_
+the BSON date ``2017-05-01``:
 
 .. code-block:: javascript
 
    { "start_date": {$gt: new Date ('2017-05-01')} }
 
-By specifying the ``Date`` type in both ``start_date`` and the ``$gt``
-comparison operator, Compass performs the ``greater than`` comparison
-chronologically, returning documents with ``start_date`` later than
-``2017-05-01``.
 
-Without the ``Date`` type specification, Compass compares the 
-``start_dates`` as strings 
-`lexicographically <https://en.wikipedia.org/wiki/Lexicographical_order>`_,
-instead of comparing the values chronologically.
+If you executed the filter without identifying the string "2017-05-01" as the
+``Date`` BSON type, Compass would return documents based on a
+`lexicographical <https://en.wikipedia.org/wiki/Lexicographical_order>`_
+comparison against the string "2017-05-01" instead of a chronological
+comparison against the date "2017-05-01"
+
+For more information on BSON comparison and sort order, see
+`BSON Comparison/Sort Order
+<https://docs.mongodb.com/manual/reference/bson-type-comparison-order>`_
 
 To specify an `ObjectID <https://docs.mongodb.com/manual/reference/method/ObjectId/>`_,
 use the format ``ObjectId('<id>')``, as in the following filter example:

--- a/source/query-bar.txt
+++ b/source/query-bar.txt
@@ -62,17 +62,23 @@ The Compass :guilabel:`Filter` supports using the :program:`mongo`
 shell mode representation of the MongoDB Extended JSON `BSON data types
 <https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson-data-types-and-associated-representations>`_.
 
-For example, The following filter returns documents where
-``start_date`` is chronologically later than the BSON ``Date``
+For example, the following filter returns documents where
+``start_date`` is greater than than the BSON ``Date``
 ``2017-05-01``:
 
 .. code-block:: javascript
 
    { "start_date": {$gt: new Date ('2017-05-01')} }
 
-Without the ``Date`` type specified in the filter, Compass would
-perform the ``greater than`` comparison using strings instead of
-comparing the ``Date`` values chronologically.
+By specifying the ``Date`` type in both ``start_date`` and the ``$gt``
+comparison operator, Compass performs the ``greater than`` comparison
+chronologically, returning documents with ``start_date`` later than
+``2017-05-01``.
+
+Without the ``Date`` type specification, Compass compares the 
+``start_dates`` as strings 
+`lexicographically <https://en.wikipedia.org/wiki/Lexicographical_order>`_,
+instead of comparing the values chronologically.
 
 To specify an `ObjectID <https://docs.mongodb.com/manual/reference/method/ObjectId/>`_,
 use the format ``ObjectId('<id>')``, as in the following filter example:

--- a/source/query-bar.txt
+++ b/source/query-bar.txt
@@ -59,10 +59,10 @@ operator.
 As you type, the :guilabel:`Find` button is disabled and the
 :guilabel:`Filter` label turns red until a valid query is entered.
 Filter syntax supports `BSON data types and associated representations
-<https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson-data-types-and-associated-representations>`_,
-using the same formatting used in the :program:`mongo` shell. See
-`MongoDB Extended JSON <https://docs.mongodb.com/manual/reference/mongodb-extended-json/>`_
-for details on supported data types.
+<https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson-data-types-and-associated-representations>`_
+using :program:`mongo` shell mode input. See
+:manual:`MongoDB extended JSON </reference/mongodb-extended-json/>` for
+details on supported data types.
 
 For example, the following filter example will display documents with a
 ``start_date`` field of ``2017-05-01 00:00:00.000`` provided that the
@@ -70,14 +70,14 @@ value of ``start_date`` is specified as type ``Date``:
 
 .. code-block:: javascript
 
-   { "start_date": BSONDate('2017-05-01 00:00:00.000')}
+   { "start_date": new Date('2017-05-01 00:00:00.000') }
 
 To specify an `ObjectID <https://docs.mongodb.com/manual/reference/method/ObjectId/>`_,
-use the format ``{ "$oid": "<string>" }``, as in the following filter example:
+use the format ``ObjectId('<id>')``, as in the following filter example:
 
 .. code-block:: javascript
 
-   { "_id": { "$oid": "58eee4f43d1a10a4e5339aac" } }
+   { "_id": ObjectId('59a87101f17fcbfbc9cd4374') }
 
 Project
 ~~~~~~~

--- a/source/query-bar.txt
+++ b/source/query-bar.txt
@@ -58,11 +58,9 @@ operator.
 
 As you type, the :guilabel:`Find` button is disabled and the
 :guilabel:`Filter` label turns red until a valid query is entered.
-Filter syntax supports `BSON data types and associated representations
-<https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson-data-types-and-associated-representations>`_
-using :program:`mongo` shell mode input. See
-:manual:`MongoDB extended JSON </reference/mongodb-extended-json/>` for
-details on supported data types.
+The Compass :guilabel:`Filter` supports using the :program:`mongo`
+shell mode representation of the MongoDB Extended JSON `BSON data types
+<https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson-data-types-and-associated-representations>`_.
 
 For example, the following filter example will display documents with a
 ``start_date`` field of ``2017-05-01 00:00:00.000`` provided that the

--- a/source/query-bar.txt
+++ b/source/query-bar.txt
@@ -58,9 +58,21 @@ operator.
 
 As you type, the :guilabel:`Find` button is disabled and the
 :guilabel:`Filter` label turns red until a valid query is entered.
-Filter syntax requires strict :manual:`extended JSON
-</reference/mongodb-extended-json/>` types. To specify an
-`ObjectID <https://docs.mongodb.com/manual/reference/method/ObjectId/>`_,
+Filter syntax supports `BSON data types and associated representations
+<https://docs.mongodb.com/manual/reference/mongodb-extended-json/#bson-data-types-and-associated-representations>`_,
+using the same formatting used in the :program:`mongo` shell. See
+`MongoDB Extended JSON <https://docs.mongodb.com/manual/reference/mongodb-extended-json/>`_
+for details on supported data types.
+
+For example, the following filter example will display documents with a
+``start_date`` field of ``2017-05-01 00:00:00.000`` provided that the
+value of ``start_date`` is specified as type ``Date``:
+
+.. code-block:: javascript
+
+   { "start_date": BSONDate('2017-05-01 00:00:00.000')}
+
+To specify an `ObjectID <https://docs.mongodb.com/manual/reference/method/ObjectId/>`_,
 use the format ``{ "$oid": "<string>" }``, as in the following filter example:
 
 .. code-block:: javascript


### PR DESCRIPTION
Added an additional example to show the use of BSON types. Also showing the distinction between comparing strings versus comparing BSON types.

Code review: https://mongodbcr.appspot.com/153850002/

Staging: https://docs-mongodbcom-staging.corp.mongodb.com/compass/jeffreyallen/DOCSP-624/query-bar.html