### PR TITLE
Added 'autocomplete in the query bar' to the 1.9 Beta release notes. (COMPASS-695)

### DIFF
--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -12,6 +12,11 @@ Release Notes
 
 .. _latest-beta:
 
+|compass| 1.9 Beta
+------------------
+
+- Added autocomplete functionality to the query bar.
+
 |compass| 1.8 Beta
 ------------------
 


### PR DESCRIPTION
Staged at https://docs-mongodbcom-staging.corp.mongodb.com/compass/robertjustice/COMPASS-695/release-notes.html#compass-1-9-beta.