### PR TITLE
DOCSP-1503 - Documenting Compass Readonly mode

### DIFF
--- a/source/collections.txt
+++ b/source/collections.txt
@@ -10,6 +10,8 @@ Collections
    :depth: 1
    :class: singlecol
 
+.. include:: /includes/extracts/readonly-not-permitted-collections.rst
+
 .. _collection-tab:
 
 Collections View

--- a/source/databases.txt
+++ b/source/databases.txt
@@ -10,6 +10,8 @@ Databases
    :depth: 1
    :class: singlecol
 
+.. include:: /includes/extracts/readonly-not-permitted-databases.rst
+
 .. _database-tab:
 
 Databases Tab
@@ -28,7 +30,7 @@ also create or delete databases.
 
 .. figure:: /images/compass/database-view.svg
   :figwidth: 778px
-  
+
 .. _create-database:
 
 Create a Database

--- a/source/documents.txt
+++ b/source/documents.txt
@@ -12,6 +12,8 @@ Documents
    :depth: 1
    :class: singlecol
 
+.. include:: /includes/extracts/readonly-not-permitted-documents.rst
+
 .. _documents-tab:
 
 Documents Tab

--- a/source/includes/extracts-readonly-not-permitted-base.yaml
+++ b/source/includes/extracts-readonly-not-permitted-base.yaml
@@ -1,0 +1,7 @@
+ref: _readonly-not-permitted-base
+content: |
+  .. note::
+
+      {{phrase}} is not permitted in
+      :ref:`MongoDB Compass Readonly Edition <compass-readonly>`.
+...

--- a/source/includes/extracts-readonly-not-permitted.yaml
+++ b/source/includes/extracts-readonly-not-permitted.yaml
@@ -1,0 +1,28 @@
+ref: readonly-not-permitted-databases
+inherit:
+  ref: _readonly-not-permitted-base
+  file: extracts-readonly-not-permitted-base.yaml
+replacement:
+  phrase: Creating and dropping databases
+---
+ref: readonly-not-permitted-collections
+inherit:
+  ref: _readonly-not-permitted-base
+  file: extracts-readonly-not-permitted-base.yaml
+replacement:
+  phrase: Creating and dropping collections
+---
+ref: readonly-not-permitted-indexes
+inherit:
+  ref: _readonly-not-permitted-base
+  file: extracts-readonly-not-permitted-base.yaml
+replacement:
+  phrase: Creating and dropping indexes
+---
+ref: readonly-not-permitted-documents
+inherit:
+  ref: _readonly-not-permitted-base
+  file: extracts-readonly-not-permitted-base.yaml
+replacement:
+  phrase: Creating, deleting, editing and cloning documents
+...

--- a/source/includes/fact-readonly-nonpermitted-actions.rst
+++ b/source/includes/fact-readonly-nonpermitted-actions.rst
@@ -1,0 +1,13 @@
+The following actions are **not** permitted in Compass Readonly Edition:
+
+- Create and drop databases
+
+- Create and drop collections
+
+- Create, delete, edit and clone documents
+
+- Create and drop indexes
+
+- Create, delete and edit document validation rules
+
+All other functionality remains the same as in standard |compass|.

--- a/source/index.txt
+++ b/source/index.txt
@@ -12,8 +12,10 @@ MongoDB Compass
 
    - Beta Version.
 
-   To download either version, go to the `MongoDB Download Center
-   <https://www.mongodb.com/downloads?jmp=docs#compass>`_.
+   - Readonly Version (*New in version 1.12.0*).
+
+   To download any available version, go to the `MongoDB Download
+   Center <https://www.mongodb.com/downloads?jmp=docs#compass>`_.
 
 |compass| is designed to allow
 users to easily analyze and understand the contents of
@@ -28,12 +30,18 @@ performance impact on the database and can produce results quickly.
 See the :ref:`FAQ<compass-faq-sampling>`
 for further information on sampling.
 
+Compass, Compass Community, and Readonly Editions
+-------------------------------------------------
+
+MongoDB Compass is available in three versions: *Compass*,
+*Compass Community* and *Readonly*.
+
+.. _compass-and-community-eds:
+
 Compass and Compass Community Editions
---------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-*Now available in two editions: Compass Community and Compass*
-
-Both editions provide the ability to:
+Both Compass and Compass Community provide the ability to:
 
 - View, add, and delete databases and collections
 
@@ -59,6 +67,35 @@ Compass provides the following features not in the Community edition:
 
 - :doc:`Document Validation </validation>`
 
+.. _compass-readonly:
+
+Compass Readonly Edition
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+*New in version 1.12.0*
+
+A read-only version of |compass| is available which provides the
+ability to limit certain :ref:`CRUD operations <crud>` within your
+organization. In this version, users are limited strictly to
+**read operations** within MongoDB.
+
+For example, Compass Readonly Edition provides the ability to:
+
+- View :doc:`databases </databases>` and
+  :doc:`collections </collections>`
+
+- View existing :doc:`documents </documents>`
+
+- Run queries on collections
+
+- View existing :ref:`indexes <indexes-tab>`
+
+- View existing :ref:`document validation rules <validation>`
+
+.. include:: /includes/fact-readonly-nonpermitted-actions.rst
+
+For more information on user permissions and roles in MongoDB, see
+:manual:`Manage Users and Roles </tutorial/manage-users-and-roles/>`.
 
 Contact
 -------

--- a/source/indexes.txt
+++ b/source/indexes.txt
@@ -10,6 +10,8 @@ Indexes
    :depth: 1
    :class: singlecol
 
+.. include:: /includes/extracts/readonly-not-permitted-indexes.rst
+
 .. _indexes-tab:
 
 Indexes Tab
@@ -26,7 +28,7 @@ collection on the left hand pane and select the :guilabel:`Indexes` tab.
 For each index, Compass displays the following information:
 
 .. list-table::
-   
+
    * - Name and Definition
      - The name of the index and keys.
 

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -10,6 +10,14 @@ Release Notes
    :depth: 1
    :class: twocols
 
+|compass| 1.12
+--------------
+
+- Added |compass| Readonly Edition which provides the
+  ability to limit certain :ref:`CRUD operations <crud>` within your
+  organization.
+
+  .. include:: /includes/fact-readonly-nonpermitted-actions.rst
 
 |compass| 1.11
 --------------

--- a/source/validation.txt
+++ b/source/validation.txt
@@ -12,7 +12,16 @@ Document Validation
    :depth: 1
    :class: singlecol
 
-*Not Available in Compass Community Edition*
+.. note::
+
+   Document validation is not available in
+   :ref:`Compass Community Edition <compass-and-community-eds>`.
+
+   Creating, editing and dropping document validation rules is not
+   permitted in
+   :ref:`MongoDB Compass Readonly Edition <compass-readonly>`.
+   In Readonly Edition, validation rules may only be read.
+
 
 .. _validation-tab:
 .. _create-validation-rules:


### PR DESCRIPTION
Staging: https://docs-mongodbcom-staging.corp.mongodb.com/compass/jeffreyallen/DOCSP-1503/index.html

Copy review: https://mongodbcr.appspot.com/174990001/

I've updated the index page with a description of the new Readonly version. I've also including a warning on the relevant pages indicating which actions cannot be performed in the readonly edition.

Release notes have also been updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs-compass/38)
<!-- Reviewable:end -->
