### PR TITLE
Typo in release notes

### DIFF
--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -24,7 +24,7 @@ Release Notes
   Compass detects an SRV record URI on the clipboard it
   auto-completes the dialog based on the SRV record.
 
-- Made various performance and stability inprovements to the documents tab
+- Made various performance and stability inprovements to the documents tab.
 
 |compass| 1.11
 --------------


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs-compass/43)
<!-- Reviewable:end -->
