### PR TITLE
DOCSP-2285 - Document Compass Isolated Version

### DIFF
--- a/source/aggregation-pipeline-builder.txt
+++ b/source/aggregation-pipeline-builder.txt
@@ -1,3 +1,5 @@
+.. _compass-agg-builder:
+
 ============================
 Aggregation Pipeline Builder
 ============================

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -134,6 +134,11 @@ See the following screenshot for all available privacy settings options:
 .. figure:: /images/compass/privacy-settings.png
    :scale: 80 %
 
+.. note::
+
+   Crash reports and automatic updates are not available in
+   :ref:`Compass Isolated Edition <compass-isolated>`.
+
 How do I enable geographic visualizations?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -141,3 +146,5 @@ You can enable geographic visualizations in |compass| in your
 privacy settings. When :guilabel:`Enable Geographic Visualizations` is
 selected, |compass| is allowed to make requests to a third-party
 mapping service.
+
+.. include:: /includes/fact-isolated-ver-third-party-mapping.rst

--- a/source/includes/fact-isolated-ver-third-party-mapping.rst
+++ b/source/includes/fact-isolated-ver-third-party-mapping.rst
@@ -1,0 +1,4 @@
+.. note::
+
+   Third party mapping services such as Mapbox are not available in
+   :ref:`Compass Isolated Edition <compass-isolated>`.

--- a/source/index.txt
+++ b/source/index.txt
@@ -6,21 +6,33 @@ MongoDB Compass
 
 .. default-domain:: mongodb
 
-.. admonition:: |compass| is available in the following versions
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
 
-   - General Availability.
+Overview
+--------
 
-   - Beta Version.
+.. admonition:: |compass| is available in the following editions
 
-   - Readonly Version (*New in version 1.12.0*).
+   - Compass
 
-   To download any available version, go to the `MongoDB Download
+   - Compass Community Edition
+
+   - Compass Readonly Edition (*New in version 1.12.0*)
+
+   - Compass Isolated Edition (*New in version 1.14.0*)
+
+   Each |compass| edition is available in both a
+   *General Availability* and a *Beta* version. To download any
+   available version, go to the `MongoDB Download
    Center <https://www.mongodb.com/downloads?jmp=docs#compass>`_.
 
-|compass| is designed to allow
-users to easily analyze and understand the contents of
-their data collections within MongoDB and
-perform queries, without requiring knowledge of MongoDB
+|compass| allows users to easily analyze and understand the contents of
+their data collections within MongoDB and perform queries, without
+requiring knowledge of MongoDB
 :manual:`query syntax </tutorial/query-documents>`.
 
 |compass| provides users with a graphical view of their MongoDB
@@ -30,16 +42,10 @@ performance impact on the database and can produce results quickly.
 See the :ref:`FAQ<compass-faq-sampling>`
 for further information on sampling.
 
-Compass, Compass Community, and Readonly Editions
--------------------------------------------------
-
-MongoDB Compass is available in three versions: *Compass*,
-*Compass Community* and *Readonly*.
-
 .. _compass-and-community-eds:
 
 Compass and Compass Community Editions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------
 
 Both Compass and Compass Community provide the ability to:
 
@@ -52,6 +58,8 @@ Both Compass and Compass Community provide the ability to:
 - View and optimize query performance with visual explain plans
 
 - Manage indexes: view stats, create, and delete
+
+- Create and execute aggregation pipelines
 
 Compass provides the following features not in the Community edition:
 
@@ -70,7 +78,7 @@ Compass provides the following features not in the Community edition:
 .. _compass-readonly:
 
 Compass Readonly Edition
-~~~~~~~~~~~~~~~~~~~~~~~~
+------------------------
 
 *New in version 1.12.0*
 
@@ -96,6 +104,33 @@ For example, Compass Readonly Edition provides the ability to:
 
 For more information on user permissions and roles in MongoDB, see
 :manual:`Manage Users and Roles </tutorial/manage-users-and-roles/>`.
+
+.. _compass-isolated:
+
+Compass Isolated Edition
+------------------------
+
+*New in version 1.14.0*
+
+Compass Isolated Edition restricts network requests to
+:abbr:`TLS (Transport Layer Security)`-encrypted
+:abbr:`TCP (Transmission Control Protocol)` connections to the server
+chosen on the :ref:`Connect <connect-run-compass>` screen. All other
+outbound connections are not permitted in this edition.
+
+The following features are not available in Compass Isolated Edition:
+
+- Automatic updates
+
+- Telemetry data collection via
+  `Stitch <https://www.mongodb.com/cloud/stitch>`_
+
+- Map rendering in the :ref:`Schema <schema-tab>` view via third
+  party services
+
+- Intercom
+
+- Error collection and crash reporting
 
 Contact
 -------

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -10,8 +10,21 @@ Release Notes
    :depth: 1
    :class: twocols
 
+|compass| 1.14
+--------------
+
+- Added :ref:`Aggregation Pipeline Builder <compass-agg-builder>`,
+  which provides the ability to execute
+  :manual:`aggregation pipelines </core/aggregation-pipeline/>` to
+  gain additional insight into your data.
+
+- Added |compass| :ref:`Isolated Edition <compass-isolated>` which
+  restricts network requests to only the server Compass connects to.
+
 |compass| 1.13
 --------------
+
+*Released May 3, 2018*
 
 - Added ability to
   :ref:`import and export data <compass-import-export>` in **JSON** and
@@ -20,9 +33,11 @@ Release Notes
 |compass| 1.12
 --------------
 
-- Added |compass| Readonly Edition which provides the
-  ability to limit certain :ref:`CRUD operations <crud>` within your
-  organization.
+*Released March 5, 2018*
+
+- Added |compass| :ref:`Readonly Edition <compass-readonly>` which
+  provides the ability to limit certain :ref:`CRUD operations <crud>`
+  within your organization.
 
   .. include:: /includes/fact-readonly-nonpermitted-actions.rst
 
@@ -33,6 +48,8 @@ Release Notes
 
 |compass| 1.11
 --------------
+
+*Released December 17, 2017*
 
 .. include:: /includes/fact-release-notes-1.11.rst
 

--- a/source/schema.txt
+++ b/source/schema.txt
@@ -37,7 +37,7 @@ Query Bar
 From the :doc:`query bar </query-bar>` in the :guilabel:`Schema` tab, you can specify the
 query, and if you click the :guilabel:`Options`, you can also specify
 query options.
-   
+
 .. figure:: /images/compass/query-bar-schema-view.png
    :figwidth: 730px
 
@@ -173,6 +173,8 @@ displayed with interactive maps.
 .. figure:: /images/compass/geo-visualization.png
    :figwidth: 816px
 
+.. include:: /includes/fact-isolated-ver-third-party-mapping.rst
+
 View Charts of Mixed Types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -188,7 +190,6 @@ data:
 
 .. figure:: /images/compass/mixed-sample2.png
    :figwidth: 576px
-
 
 .. _build-query:
 
@@ -210,7 +211,7 @@ bar.
 
 .. include:: /includes/steps/create-query-via-builder.rst
 
-.. note:: 
+.. note::
 
    You can also use the query builder on data represented as maps.
 


### PR DESCRIPTION
Staged view: https://docs-mongodbcom-staging.corp.mongodb.com/compass/jeffreyallen/DOCSP-2285/index.html#compass-isolated

These changes should cover everything we need to address for Compass Isolated Edition. All relevant pages have had a note added where their functionality does not work with isolated version.

Also some minor tweaks to the structure of the index page since it no longer made sense to lump the Readonly / Isolated versions of Compass in with GA and Beta, since there are GA and Beta versions of both.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mongodb/docs-compass/49)
<!-- Reviewable:end -->
