### PR TITLE
Add documentation on agg pipeline builder modes.

### DIFF
--- a/source/aggregation-pipeline-builder.txt
+++ b/source/aggregation-pipeline-builder.txt
@@ -145,6 +145,10 @@ The following additional options are available:
        of the pipeline.
    * - New Pipeline
      - Resets the pipeline to its initial state.
+   * - Sample Mode (Recommended)
+     - Limits input documents to 100000 before $group, $bucket, and $bucketAuto stages.
+   * - Comment Mode
+     - Adds helper comments to each stage when being selected.
 
 .. important::
 


### PR DESCRIPTION
Adds notes on the sample mode and comment mode now in the builder.