### PR TITLE
DOCSP-3253 - Adding CSV example for import

### DIFF
--- a/source/import-export.txt
+++ b/source/import-export.txt
@@ -23,33 +23,68 @@ and export for both **JSON** and **CSV** files.
 Import Data into a Collection
 -----------------------------
 
-|compass| can import data into a collection from either a
-**JSON** or **CSV** file.
+|compass| can import data into a collection from either a **JSON** or
+**CSV** file.
 
-.. note::
+Format Your Data
+~~~~~~~~~~~~~~~~
 
-   When importing data from a **JSON** file, each document must
-   exist on its own line. There must also be a blank line at the end
-   of the file, or the last document will not be inserted.
+Before you can import your data into |compass| you must first ensure
+that it is formatted correctly.
 
-   The following example ``.json`` file imports three documents:
+.. tabs::
 
-   .. cssclass:: copyable-code
-   .. code-block:: javascript
+   tabs:
+     - id: json
+       name: JSON
+       content: |
 
-      { "type": "home", "number": "212-555-1234" }
-      { "type": "cell", "number": "646-555-4567" }
-      { "type": "office", "number": "202-555-0182"}
+         When importing data from a **JSON** file, each document must exist on
+         its own line in the file. Do not use commas at the end of lines to
+         separate documents.
 
-   .. raw:: html
+         .. example::
 
-      <br>
+            The following ``.json`` file imports three documents:
 
-   |compass| automatically generates :manual:`ObjectIDs
-   </reference/method/ObjectId/>` for these objects on import since no
-   ObjectIDs were specified in the initial JSON.
+            .. code-block:: javascript
 
-To import data into a collection:
+               { "type": "home", "number": "212-555-1234" }
+               { "type": "cell", "number": "646-555-4567" }
+               { "type": "office", "number": "202-555-0182"}
+
+            |compass| automatically generates :manual:`ObjectIDs
+            </reference/method/ObjectId/>` for these objects on import
+            since no ObjectIDs were specified in the initial JSON.
+
+     - id: csv
+       name: CSV
+       content: |
+
+         When importing data from a **CSV** file, the first line of the file
+         must be a comma-separated list of your document field names. Subsequent
+         lines in the file must be comma-separated field values in the order
+         corresponding with the field order in the first line.
+
+         .. example::
+
+            The following ``.csv`` file imports three documents:
+
+            .. code-block:: none
+
+               name,age,fav_color,pet
+               Jeff,25,green,Bongo
+               Alice,20,purple,Hazel
+               Tim,32,red,Lassie
+
+            |compass| automatically generates :manual:`ObjectIDs
+            </reference/method/ObjectId/>` for these objects on import
+            since no ObjectIDs were specified in the initial CSV file.
+
+Import Procedure
+~~~~~~~~~~~~~~~~
+
+To import your formatted data into a collection:
 
 1. Navigate to the :doc:`collection </collections>` you wish to
    import data to or export data from.
@@ -93,14 +128,13 @@ Export Data from a Collection
 
 |compass| can export data from a collection as either a
 **JSON** or **CSV** file. If you specify a query in the
-:ref:`query bar <compass-query-bar>` prior to export, Compass can
-optionally only export documents which match the specified query. If no
-query is specified, Compass exports the entire collection.
+:ref:`query bar <compass-query-bar>` prior to export, |compass-short|
+can optionally only export documents which match the specified query.
 
 To export collection data to a file:
 
 1. Click :guilabel:`Collection` in the top-level menu and select
-   :guilabel:`Export Collection`.
+   :guilabel:`Export Collection`:
 
    .. raw:: html
 
@@ -113,7 +147,7 @@ To export collection data to a file:
 
       <br>
 
-   |compass| displays the following dialog:
+   |compass-short| displays the following dialog:
 
    .. raw:: html
 
@@ -127,14 +161,15 @@ To export collection data to a file:
    which collection documents are exported. If no query has been
    specified to the query bar, this section displays ``undefined``.
 
-#. Use the toggle below the query filter to indicate whether to export
-   only the documents matched by the query or the full collection.
+#. Use the :guilabel:`Export Full Collection` toggle to indicate
+   whether to export only the documents matched by the query or the
+   full collection.
 
    .. note::
 
       Having an ``undefined`` query filter and toggling the
-      option to export the full collection both result in exporting
-      the full collection.
+      option to export the full collection both result in
+      |compass-short| exporting the full collection.
 
 #. Choose the appropriate file type and the location of the export file.
 


### PR DESCRIPTION
A note if you happen to test this procedure - there's a known bug where importing with CSV results in an extra, blank document.

Staged: https://docs-mongodbcom-staging.corp.mongodb.com/compass/jeffreyallen/DOCSP-3253/import-export.html