### PR TITLE
(DOCSP-2594): Updates and refactors to Document Validation page

### DIFF
--- a/source/includes/steps-create-validation-rule-via-builder.yaml
+++ b/source/includes/steps-create-validation-rule-via-builder.yaml
@@ -1,13 +1,15 @@
-title: Update :guilabel:`validation action` and :guilabel:`validation level`.
+title: Update :guilabel:`Validation Action` and :guilabel:`Validation Level`.
 level: 4
 ref: validation-action-level
 content: |
-   Select the appropriate :guilabel:`validation action` and
-   :guilabel:`validation level`.
-   
-   For information on validation action and level, see
-   :manual:`Document Validation </core/document-validation/>`.
-   
+   Select the appropriate :guilabel:`Validation Action` and
+   :guilabel:`Validation Level`.
+
+   For more information on validation actions and levels, see
+   :ref:`this section <validation-actions-levels>`. Additional
+   information is available in the :manual:`MongoDB Manual
+   </core/document-validation>`.
+
 ---
 title: Add, Modify, Remove a Rule.
 level: 4
@@ -48,8 +50,8 @@ content: |
    cannot create compound rules for a single field other than by the
    :guilabel:`Nullable` checkbox.
 
-   The rule categories :guilabel:`"Exists"` and :guilabel:`"Must not
-   Exist"` do not support the :guilabel:`Nullable`` checkbox.
+   The rule categories :guilabel:`Exists` and :guilabel:`Must not
+   Exist` do not support the :guilabel:`Nullable` checkbox.
 
    To delete a rule, click on the trash can icon for the rule.
 ---

--- a/source/includes/steps-create-validation-rule-via-json.yaml
+++ b/source/includes/steps-create-validation-rule-via-json.yaml
@@ -1,27 +1,41 @@
-title: Update :guilabel:`validation action` and :guilabel:`validation level`.
+title: Update :guilabel:`Validation Action` and :guilabel:`Validation Level`.
 level: 4
 ref: validation-action-level
 content: |
-   Select the appropriate :guilabel:`validation action` and
-   :guilabel:`validation level`.
-   
-   For information on validation action and level, see
-   :manual:`Document Validation </core/document-validation/>`.
+   Select the appropriate :guilabel:`Validation Action` and
+   :guilabel:`Validation Level`.
+
+   For more information on validation actions and levels, see
+   :ref:`this section <validation-actions-levels>`. Additional
+   information is available in the :manual:`MongoDB Manual
+   </core/document-validation>`.
 ---
 title: Specify the validation rules.
 level: 4
 ref: add-rule
 content: |
-   In the editor, enter the validation rules in strict JSON format. For example:
+   In the editor, enter the validation rules in strict JSON format.
 
-   .. code-block:: json
+   .. example::
 
-      {
-         "$or": [
-            { "BeginDate": { "$gt": 1950 } },
-            { "EndDate": null }
-         ]
-      }
+      The following rule only allows documents where *either* the
+      ``BeginDate`` field is greater than ``1950`` *or* the
+      ``EndDate`` field is ``null``.
+
+      .. code-block:: json
+
+         {
+            "$or": [
+               { "BeginDate": { "$gt": 1950 } },
+               { "EndDate": null }
+            ]
+         }
+
+   .. note::
+
+      If you specify a rule in the JSON editor which cannot be
+      displayed in the :guilabel:`Rule Builder`, you will not
+      be able to access the :guilabel:`Rule Builder`.
 ---
 title: Verify JSON.
 level: 4
@@ -30,7 +44,7 @@ content: |
 
    When finished editing, hit the :guilabel:`Tab` key or click outside
    the editor box.
-   
+
    If the JSON document is invalid, an error message displays. Fix any
    errors.
 ---

--- a/source/validation.txt
+++ b/source/validation.txt
@@ -1,8 +1,8 @@
 .. _validation:
 
-===================
-Document Validation
-===================
+==========
+Validation
+==========
 
 .. default-domain:: mongodb
 
@@ -14,68 +14,153 @@ Document Validation
 
 .. note::
 
-   Document validation is not available in
+   Schema validation is not available in
    :ref:`Compass Community Edition <compass-and-community-eds>`.
 
-   Creating, editing and dropping document validation rules is not
+   Creating, editing and dropping schema validation rules is not
    permitted in
    :ref:`MongoDB Compass Readonly Edition <compass-readonly>`.
    In Readonly Edition, validation rules may only be read.
 
-
 .. _validation-tab:
-.. _create-validation-rules:
 
 Validation Tab
 --------------
 
-The :guilabel:`Validation` tab displays the :manual:`document
+The :guilabel:`Validation` tab displays the :manual:`schema
 validation specification </core/document-validation>` (the validation
 rules, the validation level, and the validation action) that exists for
 a collection.
 
-From this tab, you can update the document validation specification via
-the Rule Builder or the JSON editor.
+Schema validation ensures that all documents in a
+collection follow a defined set of rules, such as conforming to a
+specific shape or only allowing a specified range of values in
+document fields.
 
-To access the :guilabel:`Validation` tab for a collection, click on the
-collection on the left hand pane.
+From this tab, you can update the schema validation specification via
+the :ref:`Rule Builder <rule-builder>` or the
+:ref:`JSON editor <json-editor>`.
+
+To view and modify the :guilabel:`Validation` for a collection, click
+on the collection on the left hand pane, then click the
+:guilabel:`Validation` tab.
 
 .. figure:: /images/compass/validation-view.png
-  :figwidth: 819px
+  :figwidth: 720px
+
+Considerations
+--------------
+
+- If the current validation rules cannot be expressed through the
+  :ref:`Rule Builder <rule-builder>`, Compass deactivates the Rule
+  Builder, and you can only modify the validation specification
+  through the :ref:`JSON editor <json-editor>` view.
+
+- Each rule applies to a single field in the collection.
+
+- No two rules in the Rule Builder can have the same field.
+
+- The Rule Builder combines validation rules for the different
+  fields as a logical ``AND``.
+
+- To specify conditions not supported by the Rule Builder or to join
+  validation rules with a logical ``OR``, use the
+  :ref:`JSON Editor <json-editor>` instead of the
+  :ref:`Rule Builder <rule-builder>`.
+
+.. _validation-actions-levels:
+
+Validation Actions and Levels
+-----------------------------
+
+You can specify :guilabel:`Validation Actions` and
+:guilabel:`Validation Levels` in the :guilabel:`Validation` tab. These
+settings dictate how rule violations are handled and the types of
+documents affected by validation.
+
+Validation Actions
+~~~~~~~~~~~~~~~~~~
+
+Validation actions determine how MongoDB handles documents that
+violate validation rules. The following table describes the
+different validation actions available:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - ``Validation Action``
+     - Description
+
+   * - ``Warning``
+     - Allows invalid documents but warns about violations.
+
+   * - ``Error``
+     - Does not allow invalid documents. With this setting,
+       MongoDB errors and rejects documents that violate
+       validation rules.
+
+Validation Levels
+~~~~~~~~~~~~~~~~~
+
+Validation levels determine how strictly MongoDB applies validation
+rules to existing documents during an update. The following table
+describes the different validation levels available:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - ``Validation Level``
+     - Description
+
+   * - ``Off``
+     - Disables validation entirely.
+
+   * - ``Moderate``
+     - Applies validation rules to inserts and to updates to
+       existing documents that already fulfill the validation
+       criteria. With the :guilabel:`Moderate` level, updates to
+       existing documents that do not fulfill the validation
+       criteria are not checked for validity.
+
+   * - ``Strict``
+     - Applies validation rules to all inserts and updates.
 
 .. _update-validation:
+.. _create-validation-rules:
+
+Create Validation Rules
+-----------------------
+
+|compass| supports two methods to create validation rules,
+the :ref:`rule-builder` and the :ref:`json-editor`.
+
+.. _rule-builder:
 
 Rule Builder
-------------
+~~~~~~~~~~~~
 
-The Rule Builder facilitates the building and modification of document
+The Rule Builder facilitates the building and modification of schema
 validation rules; however, the Rule Builder only supports a subset of
 validation conditions.
 
-.. note::
-
-   - If the current validation rules cannot be expressed through the
-     Rule Builder, Compass deactivates the Rule Builder, and you can
-     only modify the validation specification through the JSON editor
-     view.
-
-   - Each rule applies to a single field in the collection.
-
-   - No two rules in the Rule Builder can have the same field.
-
-   - The Rule Builder combines validation rules for the different
-     fields as a logical ``AND``.
-
-   - To specify conditions not supported by the Rule Builder or to join
-     validation rules with a logical ``OR``, use the JSON editor
-     instead.
-
 .. include:: /includes/steps/create-validation-rule-via-builder.rst
+
+.. _json-editor:
 
 JSON Editor
 ~~~~~~~~~~~
 
-Use the JSON editor to create validation rules.
+You can also use the JSON editor to create validation rules. You can
+use the JSON editor to create more advanced validation rules which
+the :ref:`Rule Builder <rule-builder>` may not support.
+
+The JSON editor supports validation with query filter expressions using
+the :manual:`query operators
+</reference/operator/query/#query-selectors>`, with the exception of
+:query:`$near`, :query:`$nearSphere`, :query:`$text`, and
+:query:`$where`.
 
 .. include:: /includes/steps/create-validation-rule-via-json.rst
 


### PR DESCRIPTION
This is largely refactoring / reorganization. I also moved this page to under the Documents page in the ToC, since I think it makes more sense there.

Staged: https://docs-mongodbcom-staging.corp.mongodb.com/compass/jeffreyallen/DOCSP-2594/validation.html
