### PR TITLE
(DOCSP-3810): Compass does not support near / nearshpere

### DIFF
--- a/source/query-bar.txt
+++ b/source/query-bar.txt
@@ -12,8 +12,10 @@ Query Bar
    :depth: 1
    :class: singlecol
 
-From the various Collections tabs, you can use the query bar to specify
-MongoDB queries.  For details, see :ref:`querying`.
+From the :ref:`Documents <compass-documents>`, :ref:`Schema
+<schema-tab>`, and :ref:`Explain Plan <explain-plans>` tabs, you can
+use the query bar to specify MongoDB queries to return a subset of
+documents from the collection.
 
 .. figure:: /images/compass/query-bar-documents-view.png
    :figwidth: 720px
@@ -56,6 +58,15 @@ options of the query.
 
      - The upper limit for the number of documents to return.
 
+.. note::
+
+   |compass| does not support the :manual:`$near
+   </reference/operator/query/near/>` and
+   :manual:`$nearSphere </reference/operator/query/nearSphere/>`
+   geospatial query operators in any of the query bar
+   fields, because they do not provide any additional functionality in
+   the :ref:`schema view <schema-tab>`.
+
 .. _querying:
 
 Query Bar Options
@@ -73,8 +84,8 @@ operator.
 
 .. tip::
 
-   In the :doc:`Schema </schema>` tab, you can also use the :ref:`build-query`
-   to enter a query into the query bar.
+   In the :doc:`Schema </schema>` tab, you can also use the
+   :ref:`build-query` to enter a query into the query bar.
 
 As you type, the :guilabel:`Find` button is disabled and the
 :guilabel:`Filter` label turns red until a valid query is entered.
@@ -268,24 +279,23 @@ Past Queries View
 -----------------
 
 Compass automatically stores up to 20 most recent queries for each
-collection. To view these queries, click on the ellipsis
+collection. To view these queries, click the ellipsis
 :guilabel:`(...)` button in the query bar, then click
 :guilabel:`Toggle Query History`.
 
 .. figure:: /images/compass/query-history-view.png
 
 From the :guilabel:`Past Queries` view, you can view
-:ref:`recent queries <recent-queries>` as well as
-the queries saved as :ref:`favorites <favorite-queries>` for
-the current collection.
+:ref:`recent queries <recent-queries>` and queries saved as
+:ref:`favorites <favorite-queries>` for the current collection.
 
 .. _recent-queries:
 
 Recent Queries
 ~~~~~~~~~~~~~~
 
-You can view up to 20 most recent queries for that collection. Click on
-a listed query to populate the query bar with that query.
+You can view up to 20 of the most recent queries for that collection.
+Click a listed query to populate the query bar with that query.
 
 .. figure:: /images/compass/query-history-select.png
 

--- a/source/query-plan.txt
+++ b/source/query-plan.txt
@@ -1,3 +1,5 @@
+.. _explain-plans:
+
 =============
 Explain Plans
 =============

--- a/source/schema.txt
+++ b/source/schema.txt
@@ -1,3 +1,5 @@
+.. _schema-tab:
+
 ======
 Schema
 ======
@@ -11,8 +13,6 @@ Schema
    :class: singlecol
 
 *Not Available in Compass Community Edition*
-
-.. _schema-tab:
 
 Schema Tab Overview
 -------------------
@@ -108,7 +108,7 @@ Field with Multiple Data Types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 For fields that contain multiple data types,
-Compass displays a percentage breakdown of 
+Compass displays a percentage breakdown of
 the various data types across documents. In the example below,
 the chart shows the contents of a field called ``phone_no`` in which
 81% of documents are of type ``string``, and the remaining 19% are of


### PR DESCRIPTION
My original draft had an contextual sentence so this would read:

```
MongoDB Compass does not support the $near and $nearSphere geospatial query operators in any of the query bar fields. These operators do not provide any additional functionality in the :ref:`schema view <schema-tab>`.
```

But that didn't seem necessary. Just curious if you think it might help provide some context as to *why* we do not support these operators (at this time).

Staged: https://docs-mongodbcom-staging.corp.mongodb.com/compass/jeffreyallen/DOCSP-3810/query-bar.html