### PR TITLE
(DOCSP-3809): Added support for canonicalize host name via Kerberos

### DIFF
--- a/source/includes/fact-connect-auth-info.rst
+++ b/source/includes/fact-connect-auth-info.rst
@@ -1,0 +1,85 @@
+The authentication to use if the ``mongod`` instance
+requires authentication. Select your authentication
+method from the tabs below for specific instructions:
+
+.. tabs::
+
+   tabs:
+     - id: username-pw
+       name: Username / Password
+       content: |
+         Select :guilabel:`Username / Password` if the ``mongod``
+         instance uses either MongoDB-CR or :manual:`SCRAM-SHA-1
+         </core/security-scram/>` as its authentication mechanism. If
+         selected, you must provide the :guilabel:`Username`,
+         :guilabel:`Password`, and :manual:`Authentication Database
+         </core/security-users/#user-authentication-database>` to
+         authenticate the user.
+
+         .. note::
+
+            Starting in MongoDB version 4.0, MongoDB removes support
+            for the deprecated MongoDB Challenge-Response
+            (``MONGODB-CR``) authentication mechanism.
+
+     - id: scram-sha-256
+       name: SCRAM-SHA-256
+       content: |
+         Select :guilabel:`SCRAM-SHA-256` if the ``mongod`` instance
+         uses :manual:`SCRAM-SHA-256 </core/security-scram/>` as its
+         authentication mechanism (*New in MongoDB 4.0*). If selected,
+         you must provide the :guilabel:`Username`,
+         :guilabel:`Password`, and :manual:`Authentication Database
+         </core/security-users/#user-authentication-database>` to
+         authenticate the user.
+
+         For more information on the ``SCRAM``
+         authentication mechanism, see :manual:`SCRAM
+         </manual/core/security-scram/>`.
+
+     - id: x509
+       name: X.509
+       content: |
+         *Not Available in Compass Community Edition*
+
+         Select :guilabel:`X.509` if the ``mongod`` instance uses
+         :manual:`X.509 </core/security-x.509/>` as its authentication
+         mechanism. If selected, you must provide the
+         :guilabel:`Username` to authenticate the user.
+
+     - id: kerberos
+       name: Kerberos
+       content: |
+         *Not Available in Compass Community Edition*
+
+         Select :guilabel:`Kerberos` if the ``mongod`` instance uses
+         :manual:`Kerberos </core/kerberos/>` as its authentication
+         mechanism. If selected, you must provide the
+         :manual:`Principal </core/kerberos/#principals>`,
+         :guilabel:`Password`, and :guilabel:`Service Name` to
+         authenticate the user.
+
+         You can also direct |compass| to
+         :guilabel:`Canonicalize the Host Name` by setting the
+         corresponding toggle. When you enable this setting,
+         Kerberos uses the canonicalized form of the
+         host name (``cname``) when constructing the principal for
+         |compass|.
+
+         For more information on principal name canonicalization
+         in Kerberos, see `this document
+         <https://tools.ietf.org/html/rfc6806.html>`__.
+
+     - id: ldap
+       name: LDAP
+       content: |
+         *Not Available in Compass Community Edition*
+
+         Select :guilabel:`LDAP` if the ``mongod`` instance uses
+         :manual:`LDAP </core/security-ldap-external/>` as its
+         authentication mechanism. If selected, you must provide the
+         :guilabel:`Username` and :guilabel:`Password` to authenticate
+         the user.
+
+For MongoDB permissions required to access |compass-short|,
+see :ref:`required-access`.

--- a/source/includes/list-table-ssh-connection.rst
+++ b/source/includes/list-table-ssh-connection.rst
@@ -6,44 +6,12 @@
      - The hostname of the machine where the ``mongod`` instance is
        running.
 
-       .. tip::
-
-          Starting with version 1.8.0, MongoDB Compass can detect
-          whether you have a MongoDB
-          :manual:`URI connection string </reference/connection-string>`
-          in your system clipboard and auto-populate the connection
-          dialog from the URI. Open MongoDB Compass with a URI
-          connection string in your clipboard and click :guilabel:`Yes`
-          when prompted to auto-populate the dialog.
-
    * - :guilabel:`Port`
      - The port on which ``mongod`` is running.
 
    * - :guilabel:`Authentication`
 
-     - The authentication to use if the ``mongod`` instance
-       requires authentication. Select:
-
-       - :guilabel:`Username / Password` if the ``mongod`` instance
-         uses either MongoDB-CR or SCRAM-SHA-1 as its
-         authentication mechanism.
-
-       - :guilabel:`X.509` if the ``mongod`` instance uses
-         X.509 as its authentication mechanism.
-
-         *Not Available in Compass Community Edition*
-
-       - :guilabel:`Kerberos` if the ``mongod`` instance uses
-         Kerberos as its authentication mechanism.
-
-         *Not Available in Compass Community Edition*
-
-       - :guilabel:`LDAP` if the ``mongod`` instance uses LDAP as
-         its authentication mechanism.
-
-         *Not Available in Compass Community Edition*
-
-       For MongoDB access required, see :ref:`required-access`.
+     - .. include:: /includes/fact-connect-auth-info.rst
 
    * - :guilabel:`Replica Set Name`
 

--- a/source/includes/list-table-ssl-connection.rst
+++ b/source/includes/list-table-ssl-connection.rst
@@ -6,44 +6,12 @@
      - The hostname of the machine where the ``mongod`` instance is
        running.
 
-       .. tip::
-
-          Starting with version 1.8.0, MongoDB Compass can detect
-          whether you have a MongoDB
-          :manual:`URI connection string </reference/connection-string>`
-          in your system clipboard and auto-populate the connection
-          dialog from the URI. Open MongoDB Compass with a URI
-          connection string in your clipboard and click :guilabel:`Yes`
-          when prompted to auto-populate the dialog.
-
    * - :guilabel:`Port`
      - The port on which ``mongod`` is running.
 
    * - :guilabel:`Authentication`
 
-     - The authentication to use if the ``mongod`` instance
-       requires authentication. Select:
-
-       - :guilabel:`Username / Password` if the ``mongod`` instance
-         uses either MongoDB-CR or SCRAM-SHA-1 as its
-         authentication mechanism.
-
-       - :guilabel:`X.509` if the ``mongod`` instance uses
-         X.509 as its authentication mechanism.
-
-         *Not Available in Compass Community Edition*
-
-       - :guilabel:`Kerberos` if the ``mongod`` instance uses
-         Kerberos as its authentication mechanism.
-
-         *Not Available in Compass Community Edition*
-
-       - :guilabel:`LDAP` if the ``mongod`` instance uses LDAP as
-         its authentication mechanism.
-
-         *Not Available in Compass Community Edition*
-
-       For MongoDB access required, see :ref:`required-access`.
+     - .. include:: /includes/fact-connect-auth-info.rst
 
    * - :guilabel:`Replica Set Name`
 

--- a/source/includes/list-table-unencrypted-connection.rst
+++ b/source/includes/list-table-unencrypted-connection.rst
@@ -6,44 +6,12 @@
      - The hostname of the machine where the ``mongod`` instance is
        running.
 
-       .. tip::
-
-          Starting with version 1.8.0, MongoDB Compass can detect
-          whether you have a MongoDB
-          :manual:`URI connection string </reference/connection-string>`
-          in your system clipboard and auto-populate the connection
-          dialog from the URI. Open MongoDB Compass with a URI
-          connection string in your clipboard and click :guilabel:`Yes`
-          when prompted to auto-populate the dialog.
-
    * - :guilabel:`Port`
      - The port on which ``mongod`` is running.
 
    * - :guilabel:`Authentication`
 
-     - The authentication to use if the ``mongod`` instance
-       requires authentication. Select:
-
-       - :guilabel:`Username / Password` if the ``mongod`` instance
-         uses either MongoDB-CR or SCRAM-SHA-1 as its
-         authentication mechanism.
-
-       - :guilabel:`X.509` if the ``mongod`` instance uses
-         X.509 as its authentication mechanism.
-
-         *Not Available in Compass Community Edition*
-
-       - :guilabel:`Kerberos` if the ``mongod`` instance uses
-         Kerberos as its authentication mechanism.
-
-         *Not Available in Compass Community Edition*
-
-       - :guilabel:`LDAP` if the ``mongod`` instance uses LDAP as
-         its authentication mechanism.
-
-         *Not Available in Compass Community Edition*
-
-       For MongoDB access required, see :ref:`required-access`.
+     - .. include:: /includes/fact-connect-auth-info.rst
 
    * - :guilabel:`Replica Set Name`
 

--- a/source/includes/steps-starting-compass.yaml
+++ b/source/includes/steps-starting-compass.yaml
@@ -9,6 +9,16 @@ content: |
     .. figure:: /images/compass/connect-to-host.png
       :figwidth: 626px
 
+    .. tip::
+
+       Starting with version 1.8.0, MongoDB Compass can detect
+       whether you have a MongoDB
+       :manual:`URI connection string </reference/connection-string>`
+       in your system clipboard and auto-populate the connection
+       dialog from the URI. Open MongoDB Compass with a URI
+       connection string in your clipboard and click :guilabel:`Yes`
+       when prompted to auto-populate the dialog.
+
     .. tabs::
 
        tabs:
@@ -26,7 +36,7 @@ content: |
 
              .. include:: /includes/fact-ssl-ssh-connection-warning.rst
 
-         - id: shows
+         - id: ssh
            name: Connect Using SSH
            content: |
 


### PR DESCRIPTION
Kerberos connections now provide a toggle in the UI to optionally canonicalize host names. As part of these changes, I have also done some refactoring to use tabs for the auth mechanisms, since prior we were not providing any descriptions of the mechanisms and their required fields.

Staged: https://docs-mongodbcom-staging.corp.mongodb.com/compass/jeffreyallen/DOCSP-3809/connect.html