### PR TITLE
(DOCSP-4315): Landing page cleanup

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -9,43 +9,41 @@ MongoDB Compass
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 1
+   :depth: 2
    :class: singlecol
 
-Overview
---------
+What is |compass-short|?
+------------------------
 
-.. admonition:: |compass| is available in the following editions
+|compass| is the :abbr:`GUI (Graphical User Interface)` for MongoDB.
+|compass-short| allows you to analyze and understand the contents of
+your data without formal knowledge of MongoDB
+:manual:`query syntax </tutorial/query-documents>`. In addition to
+exploring your data in a visual environment, you can also use
+|compass-short| to :ref:`optimize query performance <explain-plans>`,
+:ref:`manage indexes <compass-indexes>`, and implement
+:ref:`document validation <validation>`.
 
-   - Compass
+Compass Editions
+----------------
 
-   - Compass Community Edition
+- Compass
 
-   - Compass Readonly Edition (*New in version 1.12.0*)
+- Compass Community Edition
 
-   - Compass Isolated Edition (*New in version 1.14.0*)
+- Compass Readonly Edition (*New in version 1.12.0*)
 
-   Each |compass| edition is available in both a
-   *General Availability* and a *Beta* version. To download any
-   available version, go to the `MongoDB Download
-   Center <https://www.mongodb.com/downloads?jmp=docs#compass>`_.
+- Compass Isolated Edition (*New in version 1.14.0*)
 
-|compass| allows users to easily analyze and understand the contents of
-their data collections within MongoDB and perform queries, without
-requiring knowledge of MongoDB
-:manual:`query syntax </tutorial/query-documents>`.
-
-|compass| provides users with a graphical view of their MongoDB
-schema by randomly sampling a subset of documents from the
-collection. Sampling documents minimizes
-performance impact on the database and can produce results quickly.
-See the :ref:`FAQ<compass-faq-sampling>`
-for further information on sampling.
+Each |compass| edition is available in both a
+:guilabel:`General Availability` and a :guilabel:`Beta` version. To
+download any available version, go to the `MongoDB Download
+Center <https://www.mongodb.com/downloads?jmp=docs#compass>`_.
 
 .. _compass-and-community-eds:
 
 Compass and Compass Community Editions
---------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Both Compass and Compass Community provide the ability to:
 
@@ -78,7 +76,7 @@ Compass provides the following features not in the Community edition:
 .. _compass-readonly:
 
 Compass Readonly Edition
-------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 *New in version 1.12.0*
 
@@ -108,7 +106,7 @@ For more information on user permissions and roles in MongoDB, see
 .. _compass-isolated:
 
 Compass Isolated Edition
-------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 *New in version 1.14.0*
 
@@ -132,23 +130,6 @@ The following features are not available in Compass Isolated Edition:
 
 - Error collection and crash reporting
 
-Contact
--------
-
-Questions, concerns or feedback on |compass| are appreciated.
-To report a bug or feature request, submit a ticket to the `MongoDB
-Compass JIRA <https://jira.mongodb.org/projects/COMPASS/issues>`_. For
-other feedback, contact
-`compass@mongodb.com <mailto:compass@mongodb.com>`_.
-
-.. note::
-
-   If you have an enterprise or professional MongoDB subscription,
-   you can submit a ticket to the `Commercial Support JIRA
-   <https://jira.mongodb.com>`_ for direct feedback and support.
-
-.. _`Commercial Support JIRA`: https://jira.mongodb.com
-
 .. class:: hidden
 
    .. toctree::
@@ -161,6 +142,7 @@ other feedback, contact
       /aggregation-pipeline-builder
       /import-export
       /plugins/creating-compass-plugins
-      /release-notes
       /faq
+      /release-notes
+      /submit-feedback
 

--- a/source/indexes.txt
+++ b/source/indexes.txt
@@ -1,3 +1,5 @@
+.. _compass-indexes:
+
 =======
 Indexes
 =======

--- a/source/submit-feedback.txt
+++ b/source/submit-feedback.txt
@@ -1,0 +1,24 @@
+.. _compass-feedback:
+
+===============
+Submit Feedback
+===============
+
+.. default-domain:: mongodb
+
+Questions, concerns or feedback on |compass| are appreciated.
+
+- To report a bug or feature request, submit a ticket to the
+  `MongoDB Compass JIRA
+  <https://jira.mongodb.org/projects/COMPASS/issues>`_.
+
+- If you have an enterprise or professional MongoDB subscription,
+  you can submit a ticket to the `Commercial Support JIRA
+  <https://jira.mongodb.com>`_ for direct feedback and support.
+
+- For other feedback, contact
+  `compass@mongodb.com <mailto:compass@mongodb.com>`_.
+
+
+
+


### PR DESCRIPTION
Cleaned up the copy on the landing page and separated the Contact section to a new page.

I also added an image to the landing page, so users have an idea of what Compass actually looks like. Do we like this? Yay or neigh 🐴 ? I wasn't sure if it looked best before or after the Overview section.

Staged view: https://docs-mongodbcom-staging.corp.mongodb.com/compass/jeffreyallen/DOCSP-4315/index.html

New Feedback page: https://docs-mongodbcom-staging.corp.mongodb.com/compass/jeffreyallen/DOCSP-4315/submit-feedback.html