### PR TITLE
DOCSP-4618: Note that $slice operator doesn't work for projection

### DIFF
--- a/source/query-bar.txt
+++ b/source/query-bar.txt
@@ -309,11 +309,11 @@ as favorites. To view the list of queries saved as favorites, click on
 Limitations
 -----------
 
-- The query bar fields do not support :manual:`$near
+- The query bar fields do not support the :manual:`$near
   </reference/operator/query/near/>` and
   :manual:`$nearSphere </reference/operator/query/nearSphere/>` 
-  because they do not provide any additional functionality in
-  the :ref:`schema view <schema-tab>`.
+  geospatial query operators, because they do not provide any additional 
+  functionality in the :ref:`schema view <schema-tab>`.
 
 - The :ref:`Project <query-bar-project>` query bar option does not 
   support the :manual:`$slice </reference/operator/projection/slice/>` 

--- a/source/query-bar.txt
+++ b/source/query-bar.txt
@@ -306,49 +306,23 @@ as favorites. To view the list of queries saved as favorites, click on
 .. figure:: /images/compass/query-history-favorite.png
    :figwidth: 316px
 
+Limitations
+-----------
+
+- The query bar fields do not support :manual:`$near
+  </reference/operator/query/near/>` and
+  :manual:`$nearSphere </reference/operator/query/nearSphere/>` 
+  because they do not provide any additional functionality in
+  the :ref:`schema view <schema-tab>`.
+
+- The :ref:`Project <query-bar-project>` query bar option does not 
+  support the :manual:`$slice </reference/operator/projection/slice/>` 
+  operator.
+
 .. class:: hidden
 
    .. toctree::
       :titlesonly:
 
       /export-query-to-language
-
-Limitations
------------
-
-Limitations apply to the following query operators:
-
-- :manual:`$near
-  </reference/operator/query/near/>` and
-  :manual:`$nearSphere </reference/operator/query/nearSphere/>`
-  are not supported in any of the query bar
-  fields, because they do not provide any additional functionality in
-  the :ref:`schema view <schema-tab>`.
-
-- :manual:`$slice 
-  </reference/operator/projection/slice/>` is not supported for 
-  projections.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 

--- a/source/query-bar.txt
+++ b/source/query-bar.txt
@@ -327,6 +327,19 @@ Limitations
   </reference/operator/projection/slice/>` query operator for 
   projections.
 
+Limitations apply to the following query operators:
+
+- :manual:`$near
+  </reference/operator/query/near/>` and
+  :manual:`$nearSphere </reference/operator/query/nearSphere/>`
+  are not supported in any of the query bar
+  fields, because they do not provide any additional functionality in
+  the :ref:`schema view <schema-tab>`.
+
+- :manual:`$slice 
+  </reference/operator/projection/slice/>` is not supported for 
+  projections.
+
 
 
 

--- a/source/query-bar.txt
+++ b/source/query-bar.txt
@@ -316,17 +316,6 @@ as favorites. To view the list of queries saved as favorites, click on
 Limitations
 -----------
 
-- |compass| does not support the :manual:`$near
-  </reference/operator/query/near/>` and
-  :manual:`$nearSphere </reference/operator/query/nearSphere/>`
-  geospatial query operators in any of the query bar
-  fields, because they do not provide any additional functionality in
-  the :ref:`schema view <schema-tab>`.
-
-- |compass| does not support the :manual:`$slice 
-  </reference/operator/projection/slice/>` query operator for 
-  projections.
-
 Limitations apply to the following query operators:
 
 - :manual:`$near

--- a/source/query-bar.txt
+++ b/source/query-bar.txt
@@ -9,7 +9,7 @@ Query Bar
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 1
+   :depth: 2
    :class: singlecol
 
 From the :ref:`Documents <compass-documents>`, :ref:`Schema
@@ -57,15 +57,6 @@ options of the query.
    * - :ref:`query-bar-limit`
 
      - The upper limit for the number of documents to return.
-
-.. note::
-
-   |compass| does not support the :manual:`$near
-   </reference/operator/query/near/>` and
-   :manual:`$nearSphere </reference/operator/query/nearSphere/>`
-   geospatial query operators in any of the query bar
-   fields, because they do not provide any additional functionality in
-   the :ref:`schema view <schema-tab>`.
 
 .. _querying:
 
@@ -162,14 +153,6 @@ projection document:
 
   All fields except for the fields specified in the project document
   are returned.
-
-.. note::
-
-   With the exception of the ``_id`` field, you cannot specify both
-   field inclusion and field exclusion in the project document. With
-   the ``_id`` field, you can specify its exclusion in a project
-   document that specifies field inclusions. For example,
-   ``{ year: 1, _id: 0 }``.
 
 For more information on projection, refer to the
 :ref:`MongoDB Manual <find-projection>`.
@@ -329,3 +312,41 @@ as favorites. To view the list of queries saved as favorites, click on
       :titlesonly:
 
       /export-query-to-language
+
+Limitations
+-----------
+
+- |compass| does not support the :manual:`$near
+  </reference/operator/query/near/>` and
+  :manual:`$nearSphere </reference/operator/query/nearSphere/>`
+  geospatial query operators in any of the query bar
+  fields, because they do not provide any additional functionality in
+  the :ref:`schema view <schema-tab>`.
+
+- |compass| does not support the :manual:`$slice 
+  </reference/operator/projection/slice/>` query operator for 
+  projections.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/source/query-bar.txt
+++ b/source/query-bar.txt
@@ -309,7 +309,7 @@ as favorites. To view the list of queries saved as favorites, click on
 Limitations
 -----------
 
-- The query bar fields do not support the :manual:`$near
+- The query bar options do not support the :manual:`$near
   </reference/operator/query/near/>` and
   :manual:`$nearSphere </reference/operator/query/nearSphere/>` 
   geospatial query operators, because they do not provide any additional 


### PR DESCRIPTION
Made the following changes:
- Changed the TOC depth of the [Query Bar](https://docs-mongodbcom-staging.corp.mongodb.com/compass/melissamahoney/DOCSP-4618/query-bar.html) page to 2 so that the operators are easier to find
- Created a [Limitations](https://docs-mongodbcom-staging.corp.mongodb.com/compass/melissamahoney/DOCSP-4618/query-bar.html#limitations) section
- Removed the note from the overview and added it as a bullet in the new Limitations section
- Added a bullet to note that the $slice operator doesn't work for projection