### PR TITLE
(DOCSP-5918): Support for wildcard indexes

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -136,6 +136,7 @@ extlinks = {
     'source': ('https://github.com/mongodb/mongo/blob/master/%s', ''),
     'docsgithub' : ( 'http://github.com/mongodb/docs/blob/' + conf.git.branches.current + '/%s', ''),
     'manual': ('http://docs.mongodb.org/manual%s', ''),
+    'manual-next': ('http://docs.mongodb.org/master%s', ''),
     'bic': ('https://docs.mongodb.com/bi-connector/current%s',''),
     'product': ('http://www.mongodb.com/products/%s?jmp=docs',''),
     'dl': ('http://www.mongodb.com/download-center/%s?jmp=docs',''),

--- a/source/includes/steps-create-index.yaml
+++ b/source/includes/steps-create-index.yaml
@@ -17,7 +17,7 @@ title: Add fields to index.
 level: 4
 ref: index-fields
 content: |
-   To specify a key for the index, select the field and the index type
+   To specify a key for the index, select the field and the index type.
    To index additional fields, click :guilabel:`Add Another Field`.
 ---
 title: Optional. Specify the index options.
@@ -37,8 +37,8 @@ content: |
 
       * - Build index in the background
 
-        - If checked, the MongoDB deployment remains available during
-          the index build operation.
+        - If checked, ensure that the MongoDB deployment remains
+          available during the index build operation.
 
         - :manual:`Background Construction </core/index-creation/index.html#background-construction>`
 
@@ -72,8 +72,8 @@ content: |
 
       * - Wildcard projection (*New in MongoDB 4.2*)
         
-        - If checked, the index supports unknown or arbitrary fields
-          which match the specified projection.
+        - If checked, support unknown or arbitrary fields
+          which match the specified projection in the index.
 
         - :manual-next:`Wildcard Indexes </core/index-wildcard/>`
 ---

--- a/source/includes/steps-create-index.yaml
+++ b/source/includes/steps-create-index.yaml
@@ -27,18 +27,55 @@ content: |
 
    |compass-short| supports the following index options:
 
-   * `Build the index in the background <https://docs.mongodb.com/master/core/index-creation/index.html#background-construction>`_
+   .. list-table::
+      :header-rows: 1
+      :widths: 40 60 20
 
-   * :manual:`Create a unique index </core/index-unique>`
+      * - Option
+        - Description
+        - More Information
 
-   * :manual:`Create a TTL Index </core/index-ttl>`
+      * - Build index in the background
 
-   * :manual:`Create a partial index </core/index-partial/>`
+        - If checked, the MongoDB deployment remains available during
+          the index build operation.
 
-   * `Use custom collation <https://docs.mongodb.com/manual/indexes/index.html#indexes-and-collation>`_
+        - :manual:`Background Construction </core/index-creation/index.html#background-construction>`
 
-     For information on the Custom Collation settings, see :manual:`Collation Document </reference/collation/#collation-document>`
-     in the MongoDB manual.
+      * - Create unique index
+
+        - If checked, ensure that the indexed fields do not
+          store duplicate values.
+
+        - :manual:`Unique Indexes </core/index-unique>`
+
+      * - Create :abbr:`TTL (Time to Live)`
+
+        - If checked, automatically delete documents after a
+          specified number of seconds since the indexed field value.
+
+        - :manual:`TTL Indexes </core/index-ttl>`
+
+      * - Partial filter expression
+      
+        - If checked, only index documents which match the specified
+          filter expression.
+      
+        - :manual:`Partial Indexes </core/index-partial/>`
+
+      * - Use custom collation
+
+        - If checked, create a custom collation for the index
+          using the options provided in |compass-short|.
+
+        - :manual:`Collation Document </reference/collation/#collation-document>`
+
+      * - Wildcard projection (*New in MongoDB 4.2*)
+        
+        - If checked, the index supports unknown or arbitrary fields
+          which match the specified projection.
+
+        - :manual-next:`Wildcard Indexes </core/index-wildcard/>`
 ---
 title: Click :guilabel:`Create` to create the index.
 level: 4


### PR DESCRIPTION
Compass supports creating wildcard indexes. There is a bit of refactoring done as part of this change. Now, instead of linking the index options and linking out to more information, we include a brief one-line description of each option. We still link out to the manual for more info.

JIRA: [DOCSP-5918](https://jira.mongodb.org/browse/DOCSP-5918)

Staged: [Index Options](https://docs-mongodbcom-staging.corp.mongodb.com/compass/jeffreyallen/DOCSP-5918/indexes.html#optional-specify-the-index-options)