### PR TITLE
1.20 release notes

### DIFF
--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -10,6 +10,48 @@ Release Notes
    :depth: 1
    :class: twocols
 
+|compass| 1.20
+--------------
+
+*Released November, 2019*
+
+- New and improved :guilabel:`New Connection` user experience with
+  support for all connection options.
+
+- Added support for:
+
+  - Cloning :guilabel:`Favorites`.
+
+  - Adding, viewing and editing documents in JSON.
+
+  - Querying UUIDs via the :guilabel:`Documents` query bar or in
+    :guilabel:`Aggregations`.
+
+- Added support for the following aggregation pipeline operators:
+
+  - :manual:`$set </reference/operator/aggregation/set/>`
+
+  - :manual:`$unset </reference/operator/aggregation/unset/>`
+
+  - :manual:`$replaceWith </manual/reference/operator/aggregation/replaceWith/>`
+
+- Improved inline documentation for aggregation pipeline arguments.
+
+- Removed ``$limit`` ahead of the ``$count`` stage in the aggregation
+  pipeline builder to get accurate counts on large collections. Prior
+  versions of |compass| placed a ``$limit`` stage before ``$count``
+  stages in the :guilabel:`Aggregations` pipeline builder for large
+  collections, even when sample mode was disabled.
+
+- Removed the old community license from Compass Community Edition.
+
+- Various bug fixes and improvements.
+
+When you update |compass| to version 1.20, you will need to allow access
+to your system storage for each item in :guilabel:`Recents` and
+:guilabel:`Favorites`. This should be the last update that requires you
+to enter your keychain password.
+
 |compass| 1.19
 --------------
 

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -15,17 +15,18 @@ Release Notes
 
 *Released November, 2019*
 
-- New and improved :guilabel:`New Connection` user experience with
-  support for all connection options.
+- New and improved :ref:`Connection <connect-run-compass>` experience
+  with support for all connection options.
 
-- Added support for:
+- Improved user experience for saving and sharing 
+  :ref:`Favorite Connections <favorite-connections>`.
 
-  - Cloning :guilabel:`Favorites`.
+- Added JSON mode for managing documents. With JSON mode, you can
+  now insert multiple documents at once.
 
-  - Adding, viewing and editing documents in JSON.
-
-  - Querying UUIDs via the :guilabel:`Documents` query bar or in
-    :guilabel:`Aggregations`.
+- Added support for querying UUIDs via the 
+  :ref:`Documents <documents-tab>` query bar or in the
+  :ref:`Aggregation Pipeline Builder <compass-agg-builder>`.
 
 - Added support for the following aggregation pipeline operators:
 
@@ -37,20 +38,23 @@ Release Notes
 
 - Improved inline documentation for aggregation pipeline arguments.
 
-- Removed ``$limit`` ahead of the ``$count`` stage in the aggregation
-  pipeline builder to get accurate counts on large collections. Prior
-  versions of |compass| placed a ``$limit`` stage before ``$count``
-  stages in the :guilabel:`Aggregations` pipeline builder for large
+- Removed :manual:`$limit </reference/operator/aggregation/limit/>`
+  ahead of the 
+  :manual:`$count </reference/operator/aggregation/count/>` stage in 
+  the aggregation pipeline builder to ensure accurate counts on large 
+  collections. Prior versions of |compass| placed a ``$limit`` stage 
+  before ``$count`` stages in the 
+  :ref:`Aggregation Pipeline Builder <compass-agg-builder>` for large 
   collections, even when sample mode was disabled.
-
-- Removed the old community license from Compass Community Edition.
 
 - Various bug fixes and improvements.
 
-When you update |compass| to version 1.20, you will need to allow access
-to your system storage for each item in :guilabel:`Recents` and
-:guilabel:`Favorites`. This should be the last update that requires you
-to enter your keychain password.
+.. note::
+
+   When you update |compass| to version 1.20, you will need to allow 
+   access to your system storage for each item in :guilabel:`Recents` 
+   and :guilabel:`Favorites`. This should be the last update that 
+   requires you to enter your keychain password.
 
 |compass| 1.19
 --------------


### PR DESCRIPTION
[Staged view](https://docs-mongodbcom-staging.corp.mongodb.com/compass/zach.carr/1.20-release-notes/release-notes.html)

[Compass releases](https://github.com/mongodb-js/compass/releases)
[UUID queries in 1.20](https://jira.mongodb.org/browse/DOCSP-6645) (approved for release notes via Slack conversation)
[Note: final keychain requests when updating to 1.20](https://jira.mongodb.org/browse/DOCSP-6962)

*These release notes still need an exact date.