### PR TITLE
(DOCSP-6064): Clarify Compass refresh behavior for documents

### DIFF
--- a/source/documents/view.txt
+++ b/source/documents/view.txt
@@ -150,3 +150,10 @@ Encrypted Fields
       .. figure:: /images/compass/encrypted-fields-table.png
          :figwidth: 696px
          :alt: Encrypted field in table view
+
+Document Refresh Behavior
+-------------------------
+
+|compass-short| refreshes the returned documents when you run a *new*
+query in the Query Bar. When you re-run the same query, |compass-short|
+does not re-query the database for new documents.


### PR DESCRIPTION
Want to clarify that Compass only refreshes the documents view when you run a new query. Re-running the same query does not return new documents.

Staged: [Refresh Behavior](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker/DOCSP-6064/documents/view.html#document-refresh-behavior)