### PR TITLE
(DOCSP-8369) Explain what indexes are on the Manage Indexes page

### DIFF
--- a/source/indexes.txt
+++ b/source/indexes.txt
@@ -12,6 +12,8 @@ Manage Indexes
    :depth: 1
    :class: singlecol
 
+To learn about Indexes, see :manual:`Indexes </indexes>`.
+
 .. _indexes-tab:
 
 Indexes Tab

--- a/source/indexes.txt
+++ b/source/indexes.txt
@@ -21,10 +21,10 @@ To improve query performance, build indexes on fields that appear often
 in queries and for all operations that 
 :ref:`sort by a field <query-bar-sort>`.
 
-- Queries on an indexed field use the index to limit the number of 
+- Queries on an indexed field can use the index to limit the number of 
   documents that must be scanned to find matching documents.
 
-- Sort operations on an indexed field return documents pre-sorted 
+- Sort operations on an indexed field can return documents pre-sorted 
   by the index.
 
 To learn more about indexes, see :manual:`Indexes </indexes>`.

--- a/source/indexes.txt
+++ b/source/indexes.txt
@@ -12,16 +12,20 @@ Manage Indexes
    :depth: 1
    :class: singlecol
 
-Indexes are special data structures that support the efficient 
-execution of queries in MongoDB. Indexes store a portion of a 
-collection's data in an easy-to-traverse form, thereby supporting 
-efficient equality matches and sort operations.
+Indexes are special data structures that improve query performance.
+Indexes store a portion of a collection's data in an easy-to-traverse 
+form. The index stores the value of a specific field or set of fields, 
+ordered by the value of the field.
 
 To improve query performance, build indexes on fields that appear often 
 in queries and for all operations that 
-:ref:`sort by a field <query-bar-sort>`. Queries on an indexed field 
-use the index to limit the number of documents that must be scanned or 
-to return a set of documents pre-sorted by that index.
+:ref:`sort by a field <query-bar-sort>`.
+
+- Queries on an indexed field use the index to limit the number of 
+  documents that must be scanned to find matching documents.
+
+- Sort operations on an indexed field return documents pre-sorted 
+  by the index.
 
 To learn more about indexes, see :manual:`Indexes </indexes>`.
 
@@ -31,7 +35,7 @@ To learn more about indexes, see :manual:`Indexes </indexes>`.
    Indexes have some negative performance impact on write operations. 
    For collections with high write-to-read ratio, indexes are expensive 
    since each insert must also update any indexes. For a detailed list 
-   of considerations for Indexes, see
+   of considerations for indexes, see
    :manual:`Operational Considerations for Indexes <core/data-model-operations/#data-model-indexes>`.
 
 .. _indexes-tab:

--- a/source/indexes.txt
+++ b/source/indexes.txt
@@ -21,7 +21,7 @@ To improve query performance, build indexes on fields that appear often
 in queries and for all operations that 
 :ref:`sort by a field <query-bar-sort>`. Queries on an indexed field 
 use the index to limit the number of documents that must be scanned or 
-to return a set of documents pre-sorted by the index.
+to return a set of documents pre-sorted by that index.
 
 To learn more about indexes, see :manual:`Indexes </indexes>`.
 

--- a/source/indexes.txt
+++ b/source/indexes.txt
@@ -12,16 +12,25 @@ Manage Indexes
    :depth: 1
    :class: singlecol
 
-Indexes are special data structures that store a small portion of a collection’s data set in an easy-to-traverse form. Indexes support the efficient execution of queries in MongoDB.
+Indexes are special data structures that store a small portion of a 
+collection’s data set in an easy-to-traverse form. Indexes support the 
+efficient execution of queries in MongoDB.
 
-To improve query performance, build indexes on fields that appear often in queries and for all operations that sort by a field. Queries on the indexed field use the index to limit the number of documents that must be scanned.
+To improve query performance, build indexes on fields that appear often 
+in queries and for all operations that sort by a field. Queries on the 
+indexed field use the index to limit the number of documents that must 
+be scanned.
 
 To learn more about indexes, see :manual:`Indexes </indexes>`.
 
-.. admonition:: Potential Tradeoff
-   :class: important
+.. admonition:: Considerations
+   :class: note
 
-   Indexes have some negative performance impact on write operations. For collections with high write-to-read ratio, indexes are expensive since each insert must also update any indexes.
+   Indexes have some negative performance impact on write operations. 
+   For collections with high write-to-read ratio, indexes are expensive 
+   since each insert must also update any indexes. For a list of 
+   considerations, see 
+   :manual:`Operational Considerations for Indexes <core/data-model-operations/#data-model-indexes>`.
 
 .. _indexes-tab:
 

--- a/source/indexes.txt
+++ b/source/indexes.txt
@@ -12,14 +12,16 @@ Manage Indexes
    :depth: 1
    :class: singlecol
 
-Indexes are special data structures that store a small portion of a 
-collection’s data set in an easy-to-traverse form. Indexes support the 
-efficient execution of queries in MongoDB.
+Indexes are special data structures that support the efficient 
+execution of queries in MongoDB. Indexes store a portion of a 
+collection's data in an easy-to-traverse form, thereby supporting 
+efficient equality matches and sort operations.
 
 To improve query performance, build indexes on fields that appear often 
-in queries and for all operations that sort by a field. Queries on the 
-indexed field use the index to limit the number of documents that must 
-be scanned.
+in queries and for all operations that 
+:ref:`sort by a field <query-bar-sort>`. Queries on an indexed field 
+use the index to limit the number of documents that must be scanned or 
+to return a set of documents pre-sorted by the index.
 
 To learn more about indexes, see :manual:`Indexes </indexes>`.
 
@@ -28,8 +30,8 @@ To learn more about indexes, see :manual:`Indexes </indexes>`.
 
    Indexes have some negative performance impact on write operations. 
    For collections with high write-to-read ratio, indexes are expensive 
-   since each insert must also update any indexes. For a list of 
-   considerations, see 
+   since each insert must also update any indexes. For a detailed list 
+   of considerations for Indexes, see
    :manual:`Operational Considerations for Indexes <core/data-model-operations/#data-model-indexes>`.
 
 .. _indexes-tab:

--- a/source/indexes.txt
+++ b/source/indexes.txt
@@ -12,7 +12,16 @@ Manage Indexes
    :depth: 1
    :class: singlecol
 
-To learn about Indexes, see :manual:`Indexes </indexes>`.
+Indexes are special data structures that store a small portion of a collection’s data set in an easy-to-traverse form. Indexes support the efficient execution of queries in MongoDB.
+
+To improve query performance, build indexes on fields that appear often in queries and for all operations that sort by a field. Queries on the indexed field use the index to limit the number of documents that must be scanned.
+
+To learn more about indexes, see :manual:`Indexes </indexes>`.
+
+.. admonition:: Potential Tradeoff
+   :class: important
+
+   Indexes have some negative performance impact on write operations. For collections with high write-to-read ratio, indexes are expensive since each insert must also update any indexes.
 
 .. _indexes-tab:
 

--- a/source/indexes.txt
+++ b/source/indexes.txt
@@ -73,14 +73,6 @@ For each index, Compass displays the following information:
      - Any special properties (such as uniqueness, partial) of the
        index.
 
-Limitations
------------
-
-- .. include:: /includes/extracts/readonly-not-permitted-indexes.rst
-
-- The :guilabel:`Indexes` tab is not available if you are connected 
-  to a :atlas:`Data Lake </data-lake>`. 
-
 .. _create-index:
 
 Create an Index
@@ -97,3 +89,11 @@ Drop an Index
 ---------------
 
 .. include:: /includes/steps/drop-index.rst
+
+Limitations
+-----------
+
+- .. include:: /includes/extracts/readonly-not-permitted-indexes.rst
+
+- The :guilabel:`Indexes` tab is not available if you are connected 
+  to a :atlas:`Data Lake </data-lake>`. 


### PR DESCRIPTION
[Ticket](https://jira.mongodb.org/browse/DOCSP-8369)
[Staged](https://docs-mongodbcom-staging.corp.mongodb.com/compass/zach.carr/DOCSP-8369/indexes.html)

Added an untitled overview section that provides some context for a user who doesn't know what indexes are or how to use them. It's meant to frame the page or get them started reading the server docs.

Added an admonition calling out potential tradeoffs.