### PR TITLE
Add "export driver syntax" release note

### DIFF
--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -15,6 +15,9 @@ Release Notes
 
 *Released December 5, 2019*
 
+- Added the option to include driver syntax when
+  :ref:`exporting queries to a language <compass-export-query>`.
+
 - New and improved :ref:`Connection <connect-run-compass>` experience
   with support for all connection options.
 


### PR DESCRIPTION
Adding a missing release note for a 1.20 feature (docs for that feature already merged to master and beta).