### PR TITLE
COMPASS-3986: Adding migration information to docs

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -40,7 +40,9 @@ Available |compass-short| Editions
 
    * - :guilabel:`Compass Community`
      - Designed for developing with MongoDB and includes a
-       subset of the features of Compass.
+       subset of the features of Compass. Note that this
+       version is deprecated and users are recommended to
+       use the full free version of Compass.
 
    * - :guilabel:`Compass`
      - Full version of MongoDB Compass, with all features and

--- a/source/index.txt
+++ b/source/index.txt
@@ -38,12 +38,6 @@ Available |compass-short| Editions
    * - Edition
      - Description
 
-   * - :guilabel:`Compass Community`
-     - Designed for developing with MongoDB and includes a
-       subset of the features of Compass. Note that this
-       version is deprecated and users are recommended to
-       use the full free version of Compass.
-
    * - :guilabel:`Compass`
      - Full version of MongoDB Compass, with all features and
        capabilities.
@@ -56,6 +50,19 @@ Available |compass-short| Editions
      - Does not initiate any network requests
        except to the MongoDB server to which |compass-short| connects.
        This edition is designed for highly secure environments.
+
+   * - :guilabel:`Compass Community`
+     - .. important::
+       
+          This version is deprecated. Instead, use the full free version
+          of |compass|. To learn how to migrate from Compass Community
+          to the fully-featured Compass edition, see
+          :ref:`migrate-from-community`.
+     
+       Designed for developing with MongoDB and includes a
+       subset of the features of Compass.
+       
+       
 
 .. _compass-feature-table:
 
@@ -70,17 +77,17 @@ suit your needs.
    :widths: 40 15 15 15 15
 
    * -
-     - Compass Community
      - Compass
      - Compass Readonly
      - Compass Isolated
+     - Compass Community *(Deprecated)*
 
    * - Interact with :ref:`documents <compass-documents>`,
        :ref:`collections <collection-tab>`, and
        :ref:`databases <database-tab>` with full CRUD functionality
      - |checkmark|
+     - 
      - |checkmark|
-     -
      - |checkmark|
 
    * - Create and execute :ref:`queries <compass-query-bar>` and
@@ -92,47 +99,47 @@ suit your needs.
 
    * - Create and delete :ref:`indexes <compass-indexes>`
      - |checkmark|
+     - 
      - |checkmark|
-     -
      - |checkmark|
 
    * - View and optimize query performance with visual
        :ref:`explain plans <explain-plans>`
      - |checkmark|
+     - 
      - |checkmark|
-     -
      - |checkmark|
 
    * - Kerberos, LDAP, and x.509 authentication
-     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     - 
 
    * - :doc:`Schema Analysis </schema>`
-     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     - 
 
    * - :doc:`Real Time Server Stats </performance>`
-     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     - 
 
    * - Create, delete and edit :ref:`document validation <validation>`
        rules
-     -
      - |checkmark|
-     -
+     - 
      - |checkmark|
+     - 
 
    * - Error collection and crash reporting
      - |checkmark|
      - |checkmark|
+     - 
      - |checkmark|
-     -
 
 MongoDB Compass is Source Available
 -----------------------------------

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -1,8 +1,8 @@
 .. _upgrade-compass:
 
-=====================================
-Upgrade Compass to the Latest Version
-=====================================
+=======================
+Upgrade MongoDB Compass
+=======================
 
 .. default-domain:: mongodb
 
@@ -42,24 +42,44 @@ You can enable automatic updates to the latest version of Compass on the
 Instead, |compass-short| prompts you to upgrade when a new version is
 available.
 
-Migrating to Compass from Compass Community
--------------------------------------------
+.. _migrate-from-community:
 
-For users moving to the full version of Compass from Compass Community
-and would like to retain their saved data, please copy the following
-folders from the MongoDB Compass Community data folder to the
-MongoDB Compass data folder.
+Migrate to Compass from Compass Community
+-----------------------------------------
 
-- ``Connections``
-- ``FavoriteQueries``
-- ``RecentQueries``
-- ``SavedPipelines``
+To migrate from Compass Community edition to the fully-featured
+edition of Compass and retain any saved data such as saved connection
+strings and favorite queries, you must migrate that data to your
+new edition of |compass|.
 
-The data folder is located in:
+1. Download the fully-featured edition of |compass| from the
+   {+download-page+}.
 
-- ``%APPDATA%/Roaming`` on Windows
-- ``~/Library/Application Support`` on MacOS
-- ``$XDG_CONFIG_HOME`` or `~/.config` on Linux
+#. Refer to the following table to see where your |compass| data
+   is stored based on your operating system:
+
+   .. list-table::
+      :header-rows: 1
+
+      * - Operating System
+        - Data Location
+
+      * - macOS
+        - ``~/Library/Application Support``
+
+      * - Windows
+        - ``%APPDATA%/Roaming``
+
+      * - Linux
+        - ``$XDG_CONFIG_HOME`` or ``~/.config``
+
+#. Move the following folders from your Compass Community edition folder
+   to your fully-featured Compass folder:
+
+   - ``Connections``
+   - ``FavoriteQueries``
+   - ``RecentQueries``
+   - ``SavedPipelines``
 
 .. seealso::
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -42,6 +42,25 @@ You can enable automatic updates to the latest version of Compass on the
 Instead, |compass-short| prompts you to upgrade when a new version is
 available.
 
+Migrating to Compass from Compass Community
+-------------------------------------------
+
+For users moving to the full version of Compass from Compass Community
+and would like to retain their saved data, please copy the following
+folders from the MongoDB Compass Community data folder to the
+MongoDB Compass data folder.
+
+- ``Connections``
+- ``FavoriteQueries``
+- ``RecentQueries``
+- ``SavedPipelines``
+
+The data folder is located in:
+
+- ``%APPDATA%/Roaming`` on Windows
+- ``~/Library/Application Support`` on MacOS
+- ``$XDG_CONFIG_HOME`` or `~/.config` on Linux
+
 .. seealso::
 
    :ref:`download-install`


### PR DESCRIPTION
This is basically the content, I'll leave formatting decisions up to the docs team. :)

We just need a section in the docs to tell people how to migrate from Compass Community to Compass and a note that Compass Community is deprecated.