### PR TITLE
Revert "(DOCSP-13461): Compass does not require a password for Kerberos authenticated connection but doc says required"

### DIFF
--- a/source/connect.txt
+++ b/source/connect.txt
@@ -34,9 +34,6 @@ Considerations
   :guilabel:`SRV record` or :guilabel:`Replica Set Name` when 
   filling in your connection information.
 
-- If you are using Kerberos as your authenticaion mechanism, do not 
-  specify the :guilabel:`Password` in the connection form.
-
 - .. include:: /includes/fact-non-genuine-warning.rst
 
 Connect

--- a/source/includes/steps-starting-compass-individual-fields.yaml
+++ b/source/includes/steps-starting-compass-individual-fields.yaml
@@ -141,9 +141,10 @@ content: |
                  Select :guilabel:`Kerberos` if the deployment uses
                  :manual:`Kerberos </core/kerberos/>` as
                  its authentication mechanism. If selected, you must
-                 provide the :manual:`Principal </core/kerberos/#principals>`
-                 and :guilabel:`Service Name` to authenticate the user. 
-                 Leave the :guilabel:`Password` field blank. 
+                 provide the
+                 :manual:`Principal </core/kerberos/#principals>`,
+                 :guilabel:`Password`, and :guilabel:`Service Name` to
+                 authenticate the user.
 
                  You can also direct |compass| to
                  :guilabel:`Canonicalize the Host Name` by setting the

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -177,10 +177,6 @@ Release Notes
 
 - Various bug fixes and improvements.
 
-- As of this version, you should not provide a :guilabel:`Password` when 
-  using :manual:`Kerberos </core/kerberos/>` as the authentication mechanism. 
-
-
 |compass| 1.15
 --------------
 


### PR DESCRIPTION
Reverts mongodb/docs-compass#226