### PR TITLE
Fixed preferences path on Windows

### DIFF
--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -68,7 +68,7 @@ new edition of |compass|.
         - ``~/Library/Application Support``
 
       * - Windows
-        - ``%APPDATA%/Roaming``
+        - ``%APPDATA%``
 
       * - Linux
         - ``$XDG_CONFIG_HOME`` or ``~/.config``


### PR DESCRIPTION
Just tried this and it looks like `%APPDATA%`
already points to the `Roaming` directory.