### PR TITLE
(DOCSP-9295): Adding file locations for saved favorites

### DIFF
--- a/source/aggregation-pipeline-builder.txt
+++ b/source/aggregation-pipeline-builder.txt
@@ -99,7 +99,7 @@ your operating system:
      - ``~/Library/Application Support/<Compass Edition>/FavoriteQueries``
 
    * - Windows
-     - ``%APPDATA%/Roaming/<Compass Edition>/FavoriteQueries``
+     - ``%APPDATA%/<Compass Edition>/FavoriteQueries``
 
    * - Linux
      - Either:

--- a/source/aggregation-pipeline-builder.txt
+++ b/source/aggregation-pipeline-builder.txt
@@ -85,6 +85,31 @@ To save your pipeline:
 
 #. Click :guilabel:`Save`.
 
+Compass stores saved pipelines in the following directory depending on
+your operating system:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 40
+   
+   * - Operating System
+     - File Location
+
+   * - macOS
+     - ``~/Library/Application Support/<Compass Edition>/FavoriteQueries``
+
+   * - Windows
+     - ``%APPDATA%/Roaming/<Compass Edition>/FavoriteQueries``
+
+   * - Linux
+     - Either:
+     
+       - ``$XDG_CONFIG_HOME/<Compass Edition>/FavoriteQueries``
+       
+         or
+         
+       - ``~/.config/<Compass Edition>/FavoriteQueries``
+
 .. _create-a-view:
 
 Create a View from Pipeline Results 

--- a/source/connect/favorite-connections.txt
+++ b/source/connect/favorite-connections.txt
@@ -21,7 +21,31 @@ Save a Favorite Connection
 
 You can save a favorite connection from the initial
 :ref:`connect screen <connect-run-compass>`, or after you have
-successfully connected to a MongoDB deployment.
+successfully connected to a MongoDB deployment. Compass saves
+favorite connections in the following directory depending on
+your operating system:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 40
+   
+   * - Operating System
+     - File Location
+
+   * - macOS
+     - ``~/Library/Application Support/<Compass Edition>/Connections``
+
+   * - Windows
+     - ``%APPDATA%/Roaming/<Compass Edition>/Connections``
+
+   * - Linux
+     - Either:
+     
+       - ``$XDG_CONFIG_HOME/<Compass Edition>/Connections``
+       
+         or
+         
+       - ``~/.config/<Compass Edition>/Connections``
 
 Save from Connect Screen
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/connect/favorite-connections.txt
+++ b/source/connect/favorite-connections.txt
@@ -36,7 +36,7 @@ your operating system:
      - ``~/Library/Application Support/<Compass Edition>/Connections``
 
    * - Windows
-     - ``%APPDATA%/Roaming/<Compass Edition>/Connections``
+     - ``%APPDATA%/<Compass Edition>/Connections``
 
    * - Linux
      - Either:

--- a/source/query/favorites.txt
+++ b/source/query/favorites.txt
@@ -28,7 +28,7 @@ on your operating system:
      - ``~/Library/Application Support/<Compass Edition>/FavoriteQueries``
 
    * - Windows
-     - ``%APPDATA%/Roaming/<Compass Edition>/FavoriteQueries``
+     - ``%APPDATA%/<Compass Edition>/FavoriteQueries``
 
    * - Linux
      - Either:

--- a/source/query/favorites.txt
+++ b/source/query/favorites.txt
@@ -6,9 +6,35 @@ View Favorite Queries
 
 .. default-domain:: mongodb
 
-From the list of recent queries for a collection, you can save queries
-as favorites. To view the list of queries saved as favorites, click on
-:guilabel:`Favorites` in the past queries view.
+From the :ref:`list of recent queries <recent-queries>` for a
+collection, you can save queries as favorites. To view the list of
+queries saved as favorites, click on :guilabel:`Favorites` in the past
+queries view.
 
 .. figure:: /images/compass/query-history-favorite.png
    :figwidth: 316px
+
+Compass saves favorite connections in the following directory depending
+on your operating system:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 40
+   
+   * - Operating System
+     - File Location
+
+   * - macOS
+     - ``~/Library/Application Support/<Compass Edition>/FavoriteQueries``
+
+   * - Windows
+     - ``%APPDATA%/Roaming/<Compass Edition>/FavoriteQueries``
+
+   * - Linux
+     - Either:
+     
+       - ``$XDG_CONFIG_HOME/<Compass Edition>/FavoriteQueries``
+       
+         or
+         
+       - ``~/.config/<Compass Edition>/FavoriteQueries``

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -60,6 +60,7 @@ new edition of |compass|.
 
    .. list-table::
       :header-rows: 1
+      :widths: 20 40
 
       * - Operating System
         - Data Location


### PR DESCRIPTION
@mmarcon, these address the updates for [DOCSP-9295](https://jira.mongodb.org/browse/DOCSP-9295). I added the file locations for all saveable items.

Staging:

[Favorite Connections](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker/DOCSP-9295/connect/favorite-connections.html#save-a-favorite-connection)

[Agg Pipelines](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker/DOCSP-9295/aggregation-pipeline-builder.html#save-a-pipeline)

[Favorite Queries](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker/DOCSP-9295/query/favorites.html)