### PR TITLE
(DOCS-13529) Clarify Compass X509 connections

### DIFF
--- a/source/includes/steps-starting-compass-individual-fields.yaml
+++ b/source/includes/steps-starting-compass-individual-fields.yaml
@@ -185,6 +185,21 @@ content: |
                  provide the  :guilabel:`Username` to authenticate
                  the user.
 
+                 .. note::
+
+                    If you are using 
+                    :atlas:`Atlas-managed certificates </security-add-mongodb-users/#select-an-authentication-method>`
+                    , your username must be prefaced by "CN="
+                    per :rfc:`2253`. For example, the username 
+                    "X509User" must be provided as "CN=X509User".
+
+                 .. note::
+
+                    If you are using an 
+                    :manual:`SRV record </reference/connection-string/#dns-seedlist-connection-format>` 
+                    in your connection string, the authentication 
+                    database defaults to ``admin``.
+
      * - :guilabel:`Favorite Name`
        - *Optional*. A name for the connection. To save the current
          connection entered as a

--- a/source/includes/steps-starting-compass-individual-fields.yaml
+++ b/source/includes/steps-starting-compass-individual-fields.yaml
@@ -193,13 +193,6 @@ content: |
                     per :rfc:`2253`. For example, the username 
                     "X509User" must be provided as "CN=X509User".
 
-                 .. note::
-
-                    If you are using an 
-                    :manual:`SRV record </reference/connection-string/#dns-seedlist-connection-format>` 
-                    in your connection string, the authentication 
-                    database defaults to ``admin``.
-
      * - :guilabel:`Favorite Name`
        - *Optional*. A name for the connection. To save the current
          connection entered as a


### PR DESCRIPTION
[Ticket](https://jira.mongodb.org/browse/DOCS-13529)
[Staged](https://docs-mongodbcom-staging.corp.mongodb.com/compass/zach.carr/DOCS-13529/connect.html#connect)

Changes are under "Fill in Individual Fields" > "X.509":

- Added a note about Atlas-managed certs
- Added a note about using SRV records

This change will need to be ported to beta.