### PR TITLE
Updated a reference to an old sampling page

### DIFF
--- a/source/includes/steps-export-filter.yaml
+++ b/source/includes/steps-export-filter.yaml
@@ -55,7 +55,7 @@ content: |
      fields. Fields which only appear in a small percentage of 
      documents may not be automatically detected.
 
-     For details on sampling, see the :ref:`FAQ <compass-faq-sampling>`.
+     For details on sampling, see :ref:`Sampling <sampling>`.
 
 ---
 title: Choose the appropriate file type.


### PR DESCRIPTION
Fixes a reference to an old sampling page - it was pushed to beta right before the sampling page update.