### PR TITLE
(DOCSP-9824): Move source-available info higher on landing page

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -61,8 +61,13 @@ Available |compass-short| Editions
      
        Designed for developing with MongoDB and includes a
        subset of the features of Compass.
-       
-       
+
+MongoDB Compass is Source Available
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+All versions of |compass| are source available and free to use. You can
+find the source repositories for |compass| at
+https://github.com/mongodb-js/compass/.
 
 .. _compass-feature-table:
 
@@ -140,14 +145,6 @@ suit your needs.
      - |checkmark|
      - 
      - |checkmark|
-
-MongoDB Compass is Source Available
------------------------------------
-
-All versions of |compass| are source available. As such, you can
-freely use and view the source repositories of all |compass| versions.
-The source repositories can be found on GitHub at
-https://github.com/mongodb-js/compass/.
 
 .. class:: hidden
 


### PR DESCRIPTION
Moved the source-available section higher on the page and simplified the language a bit.

JIRA: [DOCSP-9824](https://jira.mongodb.org/browse/DOCSP-9824)

Staged: [Landing Page](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker/DOCSP-9824/index.html)