### PR TITLE
(DOCSP-10869) Note on Automatic Creation of Object ID

### DIFF
--- a/source/documents/insert.txt
+++ b/source/documents/insert.txt
@@ -81,7 +81,7 @@ To insert documents into your collection:
 
             .. note::
               
-              ..include:: /includes/fact-automatic-objectid.rst
+              .. include:: /includes/fact-automatic-objectid.rst
               
 
          4. Click :guilabel:`Insert`.
@@ -99,7 +99,7 @@ To insert documents into your collection:
 
             .. note::
               
-              ..include:: /includes/fact-automatic-objectid.rst
+              .. include:: /includes/fact-automatic-objectid.rst
 
          Add New Fields
          ~~~~~~~~~~~~~~

--- a/source/documents/insert.txt
+++ b/source/documents/insert.txt
@@ -79,6 +79,10 @@ To insert documents into your collection:
                     { "_id" : 8751, "title" : "The Banquet", "author" : "Dante", "copies" : 2 }
                   ]
 
+            .. note::
+
+              If an object ID is not provided by user, Compass will automatically generate an object ID.
+
          4. Click :guilabel:`Insert`.
 
       .. tab:: Field-by-Field Editor

--- a/source/documents/insert.txt
+++ b/source/documents/insert.txt
@@ -80,8 +80,9 @@ To insert documents into your collection:
                   ]
 
             .. note::
-
-              If an object ID is not provided by user, Compass will automatically generate an object ID.
+              
+              ..include:: /includes/fact-automatic-objectid.rst
+              
 
          4. Click :guilabel:`Insert`.
 
@@ -98,7 +99,7 @@ To insert documents into your collection:
 
             .. note::
               
-              If an object ID is not provided by user, Compass will automatically generate an object ID.
+              ..include:: /includes/fact-automatic-objectid.rst
 
          Add New Fields
          ~~~~~~~~~~~~~~

--- a/source/documents/insert.txt
+++ b/source/documents/insert.txt
@@ -96,6 +96,10 @@ To insert documents into your collection:
             .. figure:: /images/compass/insert-document2.png
               :figwidth: 590px
 
+            .. note::
+              
+              If an object ID is not provided by user, Compass will automatically generate an object ID.
+
          Add New Fields
          ~~~~~~~~~~~~~~
 

--- a/source/includes/fact-automatic-objectid.rst
+++ b/source/includes/fact-automatic-objectid.rst
@@ -1,1 +1,3 @@
-If you do not provide an :manual:`ObjectId </reference/bson-types/#objectid>, |compass-short| automatically generates an ObjectId.
+If you do not provide an
+:manual:`ObjectId</reference/bson-types/#objectid> in your document,
+|compass-short| automatically generates an ObjectId.

--- a/source/includes/fact-automatic-objectid.rst
+++ b/source/includes/fact-automatic-objectid.rst
@@ -1,0 +1,1 @@
+If you do not provide an :manual:`ObjectId </reference/bson-types/#objectid>, |compass-short| automatically generates an ObjectId.

--- a/source/includes/fact-automatic-objectid.rst
+++ b/source/includes/fact-automatic-objectid.rst
@@ -1,3 +1,3 @@
 If you do not provide an
-:manual:`ObjectId</reference/bson-types/#objectid> in your document,
+:manual:`ObjectId</reference/bson-types/#objectid>` in your document,
 |compass-short| automatically generates an ObjectId.


### PR DESCRIPTION
Added note stating automatic creation of an object ID when one is not provided during document insertion.
Jira: https://jira.mongodb.org/browse/DOCSP-10869
Staging: https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker/DOCSP-10869/index.html