### PR TITLE
(DOCSP-1085)- Release notes for 1.22 about added embedded MongoDB Shell

### DIFF
--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -13,7 +13,7 @@ Release Notes
 |compass| 1.22
 --------------
 
-- Added an :ref:`embedded MongoDB Shell <cembedded-mongodb-shell>`. You
+- Added an :ref:`embedded MongoDB Shell <embedded-mongodb-shell>`. You
   can now test queries and operations with your database. 
    
 |compass| 1.21

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -13,7 +13,7 @@ Release Notes
 |compass| 1.22
 --------------
 
-- Added an :ref:`embedded MongoDB Shell <compass-embedded-shell>`. You
+- Added an :ref:`embedded-shell`. You
   can now test queries and operations with your database. 
    
 |compass| 1.21

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -14,7 +14,8 @@ Release Notes
 --------------
 
 - Added an :ref:`embedded MongoDB Shell <embedded-mongodb-shell>`. You
-  can now test queries and operations with your database. 
+  can use MongoDB Shell to test queries and operations in an interactive
+  JavaScript interface. 
    
 |compass| 1.21
 --------------

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -13,7 +13,7 @@ Release Notes
 |compass| 1.22
 --------------
 
-- Added an :ref:`embedded MongoDB Shell <embedded-shell>`. You
+- Added an :ref:`embedded MongoDB Shell <compass-embedded-shell>`. You
   can now test queries and operations with your database. 
    
 |compass| 1.21

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -9,6 +9,12 @@ Release Notes
    :backlinks: none
    :depth: 1
    :class: twocols
+
+|compass| 1.22
+--------------
+
+- Added an :ref:`embedded MongoDB Shell <compass-embedded-shell>`. You
+can now test queries and operations with your database. 
    
 |compass| 1.21
 --------------

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -13,7 +13,7 @@ Release Notes
 |compass| 1.22
 --------------
 
-- Added an :ref:`embedded-shell`. You
+- Added an :ref:`embedded MongoDB Shell <cembedded-mongodb-shell>`. You
   can now test queries and operations with your database. 
    
 |compass| 1.21

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -13,7 +13,7 @@ Release Notes
 |compass| 1.22
 --------------
 
-- Added an :ref:`embedded MongoDB Shell <compass-embedded-shell>`. You
+- Added an :ref:`embedded MongoDB Shell <embedded-shell>`. You
 can now test queries and operations with your database. 
    
 |compass| 1.21

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -14,7 +14,7 @@ Release Notes
 --------------
 
 - Added an :ref:`embedded MongoDB Shell <embedded-shell>`. You
-can now test queries and operations with your database. 
+  can now test queries and operations with your database. 
    
 |compass| 1.21
 --------------


### PR DESCRIPTION
Add note about an added embedded MongoDB Shell and linked back to embedded MongoDB Shell page for more info.
jira: https://jira.mongodb.org/browse/DOCSP-10856
staging: https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker/DOCSP-10856/release-notes.html