### PR TITLE
DOCSP-10756) Added step noting directions for Compass to trust macOS

### DIFF
--- a/source/install.txt
+++ b/source/install.txt
@@ -155,10 +155,10 @@ Install Compass
             permissions to run. You may be prompted to enter your
             system password before launching |compass-short|.
          
-         #. Allow macOS to trust |compass-short|. If you receive a
-         security error when starting |compass-short| indicating that the
-         developer could not be identified or verified, perform the
-         following actions:
+         7. Allow macOS to trust |compass-short|. If you receive a
+         security error when starting |compass-short| indicating that
+         the developer could not be identified or verified, perform the
+         following actions to allow |compass-short| to run:
             
             a. Open *System Preferences*.
    

--- a/source/install.txt
+++ b/source/install.txt
@@ -155,10 +155,11 @@ Install Compass
             permissions to run. You may be prompted to enter your
             system password before launching |compass-short|.
          
+         
          7. Allow macOS to trust |compass-short|. If you receive a
-         security error when starting |compass-short| indicating that
-         the developer could not be identified or verified, perform the
-         following actions to allow |compass-short| to run:
+            security error when starting |compass-short| indicating that
+            the developer could not be identified or verified, perform the
+            following actions to allow |compass-short| to run:
             
             a. Open *System Preferences*.
    

--- a/source/install.txt
+++ b/source/install.txt
@@ -154,6 +154,22 @@ Install Compass
             to modify your system settings to grant |compass-short|
             permissions to run. You may be prompted to enter your
             system password before launching |compass-short|.
+         
+         #. Allow macOS to trust |compass-short|. If you receive a
+         security error when starting |compass-short| indicating that the
+         developer could not be identified or verified, perform the
+         following actions:
+            
+            a. Open *System Preferences*.
+   
+            #. Select the *Security and Privacy* pane.
+
+            #. Under the *General* tab, click the button to the right of the
+               message about |compass-short|, labelled either
+               :guilabel:`Open Anyway` or :guilabel:`Allow Anyway`
+               depending on your version of macOS.
+
+
 
      - id: windows
        content: |

--- a/source/install.txt
+++ b/source/install.txt
@@ -139,24 +139,7 @@ Install Compass
          #. From the :guilabel:`Applications` folder, double-click on
             the |compass-short| icon to start the application.
 
-         #. After you start the application, you see the following
-            dialog:
-
-            .. figure:: /images/compass/application-downloaded-internet.png
-               :figwidth: 480px
-
-         #. Click :guilabel:`Open` to continue and launch
-            |compass-short|.
-
-         .. note::
-
-            Depending on your system's security settings, you may have
-            to modify your system settings to grant |compass-short|
-            permissions to run. You may be prompted to enter your
-            system password before launching |compass-short|.
-         
-         
-         7. Allow macOS to trust |compass-short|. If you receive a
+         #. Allow macOS to trust |compass-short|. If you receive a
             security error when starting |compass-short| indicating that
             the developer could not be identified or verified, perform the
             following actions to allow |compass-short| to run:
@@ -169,8 +152,21 @@ Install Compass
                message about |compass-short|, labelled either
                :guilabel:`Open Anyway` or :guilabel:`Allow Anyway`
                depending on your version of macOS.
+         
+         #. If necessary, re-open |compass-short|.
 
+         #. When you open |compass| for the first time, you may receive
+            a notice stating
+            that it is an application downloaded from the internet, requiring you
+            to confirm you want to open it. Click :guilabel:`Open` to continue
+            and launch |compass-short|.
 
+         .. note::
+
+            Depending on your system's security settings, you may have
+            to modify your system settings to grant |compass-short|
+            permissions to run. You may be prompted to enter your
+            system password before launching |compass-short|.
 
      - id: windows
        content: |

--- a/source/install.txt
+++ b/source/install.txt
@@ -153,7 +153,7 @@ Install Compass
                :guilabel:`Open Anyway` or :guilabel:`Allow Anyway`
                depending on your version of macOS.
          
-         #. If necessary, re-open |compass-short|.
+            #. If necessary, re-open |compass-short|.
 
          #. When you open |compass| for the first time, you may receive
             a notice stating


### PR DESCRIPTION
Added step number 7 to note how to allow macOS to trust Compass in order to fix/prevent security error.

Jira: https://jira.mongodb.org/browse/DOCSP-10756#add-comment

Staging: https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker/DOCSP-10756/index.html