### PR TITLE
(DOCSP-11049) Added note on macOS permission for Compass to run

### DIFF
--- a/source/install.txt
+++ b/source/install.txt
@@ -115,6 +115,8 @@ To download |compass-short|, you can use your preferred web browser.
                   Enterprise Linux. The |compass| installer is a
                   ``.rpm`` package.
 
+.. _compass-install:
+
 Install Compass
 ---------------
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -104,7 +104,7 @@ Procedure
    If you are running macOS Catalina, or later, you may have to modify
    your system settings to grant |compass-short| permission to run. For
    more information on how to grant access permission to
-   |compass-short|, see :ref:`download-and-install-compass`.
+   |compass-short|, see :ref:`Download and Install Compass <download-and-install-compass>`.
 
 .. seealso::
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -99,6 +99,14 @@ Procedure
 
 #. Launch the fully-featured edition of |compass|.
 
+.. note::
+
+   If you are running macOS Catalina, or later, you may have to modify
+   your system settings to grant Compass permission to run. For more
+   information on how to grant access permission to Compass, see :ref: `install-compass`.
+
 .. seealso::
 
    :ref:`download-install`
+
+

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -103,8 +103,7 @@ Procedure
 
    If you are running macOS Catalina, or later, you may have to modify
    your system settings to grant |compass-short| permission to run. For
-   more information on how to grant access permission to
-   |compass-short|, see :ref:`compass-install`.
+   more information, see :ref:`compass-install`.
 
 .. seealso::
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -104,7 +104,7 @@ Procedure
    If you are running macOS Catalina, or later, you may have to modify
    your system settings to grant |compass-short| permission to run. For
    more information on how to grant access permission to
-   |compass-short|, see :ref:`Install Compass <#install-compass>`.
+   |compass-short|, see :ref:`download-and-install-compass`.
 
 .. seealso::
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -102,8 +102,8 @@ Procedure
 .. note::
 
    If you are running macOS Catalina, or later, you may have to modify
-   your system settings to grant Compass permission to run. For more
-   information on how to grant access permission to Compass, see :ref:`install-compass`.
+   your system settings to grant |compass-short| permission to run. For more
+   information on how to grant access permission to |compass-short|, see :ref:`install-compass`.
 
 .. seealso::
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -104,7 +104,7 @@ Procedure
    If you are running macOS Catalina, or later, you may have to modify
    your system settings to grant |compass-short| permission to run. For
    more information on how to grant access permission to
-   |compass-short|, see :ref:`download-and-install-compass`
+   |compass-short|, see :ref:`install-compass`.
 .. seealso::
 
    :ref:`download-install`

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -103,7 +103,7 @@ Procedure
 
    If you are running macOS Catalina, or later, you may have to modify
    your system settings to grant Compass permission to run. For more
-   information on how to grant access permission to Compass, see :ref: `install-compass`.
+   information on how to grant access permission to Compass, see :ref:`install-compass`.
 
 .. seealso::
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -104,7 +104,8 @@ Procedure
    If you are running macOS Catalina, or later, you may have to modify
    your system settings to grant |compass-short| permission to run. For
    more information on how to grant access permission to
-   |compass-short|, see :ref:`install-compass`.
+   |compass-short|, see :ref:`compass-install`.
+
 .. seealso::
 
    :ref:`download-install`

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -104,7 +104,7 @@ Procedure
    If you are running macOS Catalina, or later, you may have to modify
    your system settings to grant |compass-short| permission to run. For
    more information on how to grant access permission to
-   |compass-short|, see :ref:`install-compass`.
+   |compass-short|, see :ref:`compass-install-compass`.
 
 .. seealso::
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -104,7 +104,7 @@ Procedure
    If you are running macOS Catalina, or later, you may have to modify
    your system settings to grant |compass-short| permission to run. For
    more information on how to grant access permission to
-   |compass-short|, see :ref:`Download and Install Compass <download-and-install-compass>`.
+   |compass-short|, see :ref:`install-compass`.
 
 .. seealso::
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -101,7 +101,7 @@ Procedure
 
 .. note::
 
-   If you are running macOS Catalina, or later, you may have to modify
+   If you are running macOS Catalina, or later versions, you may have to modify
    your system settings to grant |compass-short| permission to run. For
    more information, see :ref:`compass-install`.
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -102,8 +102,9 @@ Procedure
 .. note::
 
    If you are running macOS Catalina, or later, you may have to modify
-   your system settings to grant |compass-short| permission to run. For more
-   information on how to grant access permission to |compass-short|, see :ref:`install-compass`.
+   your system settings to grant |compass-short| permission to run. For
+   more information on how to grant access permission to
+   |compass-short|, see :ref:`Install compass <install-compass>`.
 
 .. seealso::
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -104,7 +104,7 @@ Procedure
    If you are running macOS Catalina, or later, you may have to modify
    your system settings to grant |compass-short| permission to run. For
    more information on how to grant access permission to
-   |compass-short|, see :ref:`Install compass <install-compass>`.
+   |compass-short|, see :ref:`Install Compass <#install-compass>`.
 
 .. seealso::
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -104,8 +104,7 @@ Procedure
    If you are running macOS Catalina, or later, you may have to modify
    your system settings to grant |compass-short| permission to run. For
    more information on how to grant access permission to
-   |compass-short|, see :ref:`compass-install-compass`.
-
+   |compass-short|, see :ref:`download-and-install-compass`
 .. seealso::
 
    :ref:`download-install`

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -28,6 +28,12 @@ your operating system and desired version of Compass to ensure Compass
 is compatible with your system. You do not need to uninstall previous
 versions of Compass to upgrade.
 
+.. note::
+
+   If you are running macOS Catalina or later, you may have to modify
+   your system settings to grant |compass-short| permission to run. For
+   more information, see :ref:`compass-install`.
+
 Enable Automatic Updates
 ------------------------
 
@@ -98,12 +104,6 @@ Procedure
    as your Compass Community edition folder.
 
 #. Launch the fully-featured edition of |compass|.
-
-.. note::
-
-   If you are running macOS Catalina, or later versions, you may have to modify
-   your system settings to grant |compass-short| permission to run. For
-   more information, see :ref:`compass-install`.
 
 .. seealso::
 


### PR DESCRIPTION
Added note that macOS Catalina, and later versions, may require permission to be granted to allow Compass to run. 

jira: https://jira.mongodb.org/browse/DOCSP-11049

staging: https://docs-mongodbcom-staging.corp.mongodb.com/compass/jocelynmendez/DOCSP-11049/index.html