### PR TITLE
(DOCSP-11066): Explain why users need to allow keychain access for co…

### DIFF
--- a/source/connect/favorite-connections.txt
+++ b/source/connect/favorite-connections.txt
@@ -16,6 +16,10 @@ Favorite Connections
 easily reconnect to the same MongoDB deployment using the same
 specifications.
 
+.. note::
+
+   .. include:: /includes/fact-connection-keychain-access.rst
+
 Save a Favorite Connection
 --------------------------
 

--- a/source/includes/fact-connection-keychain-access.rst
+++ b/source/includes/fact-connection-keychain-access.rst
@@ -1,0 +1,4 @@
+On macOS systems, the first time that you update |compass| to version
+1.20 or later, you will need to allow access to your system storage
+**for each** saved connection in :guilabel:`Recents` and
+:guilabel:`Favorites`. To learn more, see :ref:`keychain-access`.

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -30,6 +30,10 @@ Release Notes
 |compass| 1.20
 --------------
 
+.. note::
+
+   .. include:: /includes/fact-connection-keychain-access.rst
+
 *Released December 5, 2019*
 
 - Added the option to include driver syntax when
@@ -68,13 +72,6 @@ Release Notes
   collections, even when sample mode was disabled.
 
 - Various bug fixes and improvements.
-
-.. note::
-
-   When you update |compass| to version 1.20, you will need to allow 
-   access to your system storage for each item in :guilabel:`Recents` 
-   and :guilabel:`Favorites`. This should be the last update that 
-   requires you to enter your keychain password.
 
 |compass| 1.19
 --------------

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -1,8 +1,8 @@
 .. _upgrade-compass:
 
-=======================
-Upgrade MongoDB Compass
-=======================
+======================
+Update MongoDB Compass
+======================
 
 .. default-domain:: mongodb
 
@@ -41,6 +41,21 @@ You can enable automatic updates to the latest version of Compass on the
 |compass| does not install any updates without your explicit permission.
 Instead, |compass-short| prompts you to upgrade when a new version is
 available.
+
+.. _keychain-access:
+
+Allow Keychain Access for Recent and Favorite Connections
+---------------------------------------------------------
+
+On macOS systems, the first time that you update |compass| to version
+1.20 or later, you will need to allow access to your system storage
+**for each** saved connection in :guilabel:`Recents` and
+:guilabel:`Favorites`.
+
+When prompted for your keychain password, click :guilabel:`Always Allow`
+to prevent being prompted for your password in the future. This
+ensures |compass| has access to your saved connections when updating
+to new versions.
 
 .. _migrate-from-community:
 


### PR DESCRIPTION
…nnections

Staged pages: 

[Release Notes](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-11066/release-notes.html#compass-1-20). Tweaked the copy on the admonition and moved it higher up within the section.

[Update Compass](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-11066/upgrade.html#allow-keychain-access-for-recent-and-favorite-connections) Added a new section here explaining the keychain behavior. This is the bulk of the new content. We're emphasizing that users need to click `Always Allow` to prevent this from showing up in the future.

[Favorite Connections](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-11066/connect/favorite-connections.html) This is the same copy used in the release notes.

Some questions:

- My understanding is that this only applies to macOS, but let me know if this is incorrect.
- I'm putting this new section on the Update page since it seems like people run into this issue when they update Compass and have to move all their connections to the new version. Let me know if we want this section somewhere else, however.
- Does this only apply to connections, and not saved queries / agg pipelines?