### PR TITLE
(DOCSP-11062) Added limitation for aggregation

### DIFF
--- a/source/query-plan.txt
+++ b/source/query-plan.txt
@@ -50,5 +50,6 @@ Limitations
 
 - The :guilabel:`Explain Plan` tab is not available for aggregation. As
   an alternative, you can utilize the
-  `.explain() <https://docs.mongodb.com/manual/reference/method/db.collection.explain/#db.collection.explain>`__
+  `.explain()
+  <https://docs.mongodb.com/manual/reference/method/db.collection.explain/#db.collection.explain>`
   method from MongoDB's Embedded Shell in |compass-short|.

--- a/source/query-plan.txt
+++ b/source/query-plan.txt
@@ -52,6 +52,5 @@ Limitations
   commands <https://docs.mongodb.com/manual/aggregation/>`__. Instead,
   you can utilize the `.explain()
   <https://docs.mongodb.com/manual/reference/method/db.collection.explain/#db.collection.explain>`__
-  method from `Embedded MongoDB Shell <
-  https://docs.mongodb.com/compass/beta/embedded-shell/>`__ in
+  method from `Embedded MongoDB Shell <https://docs.mongodb.com/compass/beta/embedded-shell/>`__ in
   |compass-short|.

--- a/source/query-plan.txt
+++ b/source/query-plan.txt
@@ -42,8 +42,13 @@ You can also view the explain details in raw JSON format:
 To learn more about execution plans, see the
 :manual:`MongoDB documentation </tutorial/analyze-query-plan/>`.
 
-Limitation
-----------
+Limitations
+-----------
 
-The :guilabel:`Explain Plan` tab is not available if you are connected
-to :atlas:`Data Lake </data-lake>`.
+- The :guilabel:`Explain Plan` tab is not available if you are connected
+  to :atlas:`Data Lake </data-lake>`.
+
+- The :guilabel:`Explain Plan` tab is not available for aggregation. As
+  an alternative, you can utilize the
+  `.explain()<https://docs.mongodb.com/manual/reference/method/db.collection.explain/#db.collection.explain>`__.
+  method from MongoDB's Embedded Shell in |compass-short|.

--- a/source/query-plan.txt
+++ b/source/query-plan.txt
@@ -50,5 +50,5 @@ Limitations
 
 - The :guilabel:`Explain Plan` tab is not available for aggregation. As
   an alternative, you can utilize the
-  `.explain() <https://docs.mongodb.com/manual/reference/method/db.collection.explain/#db.collection.explain>`__.
+  `.explain() <https://docs.mongodb.com/manual/reference/method/db.collection.explain/#db.collection.explain>`__
   method from MongoDB's Embedded Shell in |compass-short|.

--- a/source/query-plan.txt
+++ b/source/query-plan.txt
@@ -51,5 +51,5 @@ Limitations
 - The :guilabel:`Explain Plan` tab is not available for aggregation. As
   an alternative, you can utilize the
   `.explain()
-  <https://docs.mongodb.com/manual/reference/method/db.collection.explain/#db.collection.explain>`
+  <https://docs.mongodb.com/manual/reference/method/db.collection.explain/#db.collection.explain>`__
   method from MongoDB's Embedded Shell in |compass-short|.

--- a/source/query-plan.txt
+++ b/source/query-plan.txt
@@ -50,5 +50,5 @@ Limitations
 
 - The :guilabel:`Explain Plan` tab is not available for aggregation. As
   an alternative, you can utilize the
-  `.explain()<https://docs.mongodb.com/manual/reference/method/db.collection.explain/#db.collection.explain>`__.
+  `.explain() <https://docs.mongodb.com/manual/reference/method/db.collection.explain/#db.collection.explain>`__.
   method from MongoDB's Embedded Shell in |compass-short|.

--- a/source/query-plan.txt
+++ b/source/query-plan.txt
@@ -48,8 +48,10 @@ Limitations
 - The :guilabel:`Explain Plan` tab is not available if you are connected
   to :atlas:`Data Lake </data-lake>`.
 
-- The :guilabel:`Explain Plan` tab is not available for aggregation. As
-  an alternative, you can utilize the
-  `.explain()
+- The :guilabel:`Explain Plan` tab is not available for `aggregation
+  commands <https://docs.mongodb.com/manual/aggregation/>`__. Instead,
+  you can utilize the `.explain()
   <https://docs.mongodb.com/manual/reference/method/db.collection.explain/#db.collection.explain>`__
-  method from MongoDB's Embedded Shell in |compass-short|.
+  method from `Embedded MongoDB Shell <
+  https://docs.mongodb.com/compass/beta/embedded-shell/>`__ in
+  |compass-short|.

--- a/source/query-plan.txt
+++ b/source/query-plan.txt
@@ -48,9 +48,8 @@ Limitations
 - The :guilabel:`Explain Plan` tab is not available if you are connected
   to :atlas:`Data Lake </data-lake>`.
 
-- The :guilabel:`Explain Plan` tab is not available for `aggregation
-  commands <https://docs.mongodb.com/manual/aggregation/>`__. Instead,
-  you can utilize the `.explain()
-  <https://docs.mongodb.com/manual/reference/method/db.collection.explain/#db.collection.explain>`__
-  method from `Embedded MongoDB Shell <https://docs.mongodb.com/compass/beta/embedded-shell/>`__ in
-  |compass-short|.
+- The :guilabel:`Explain Plan` tab is not available for
+  :manual:`aggregation commands </aggregation/>`. Instead,
+  you can utilize the :manual:`.explain()
+  </reference/method/db.collection.explain>` method from :doc:`Embedded
+  MongoDB Shell </embedded-shell>` in |compass-short|.

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -125,8 +125,7 @@ Procedure
    If you are running macOS Catalina, or later, you may have to modify
    your system settings to grant |compass-short| permission to run. For
    more information on how to grant access permission to
-   |compass-short|, see :ref:`compass-install-compass`.
-
+   |compass-short|, see :ref:`download-and-install-compass`
 .. seealso::
 
    :ref:`download-install`

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -125,7 +125,7 @@ Procedure
    If you are running macOS Catalina, or later, you may have to modify
    your system settings to grant |compass-short| permission to run. For
    more information on how to grant access permission to
-   |compass-short|, see :ref:`Install compass <install-compass>`.
+   |compass-short|, see :ref:`Install Compass <#install-compass>`.
 
 .. seealso::
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -120,12 +120,6 @@ Procedure
 
 #. Launch the fully-featured edition of |compass|.
 
-.. note::
-
-   If you are running macOS Catalina, or later versions, you may have to modify
-   your system settings to grant |compass-short| permission to run. For
-   more information, see :ref:`compass-install`.
-
 .. seealso::
 
    :ref:`download-install`

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -125,7 +125,7 @@ Procedure
    If you are running macOS Catalina, or later, you may have to modify
    your system settings to grant |compass-short| permission to run. For
    more information on how to grant access permission to
-   |compass-short|, see :ref:`Install Compass <#install-compass>`.
+   |compass-short|, see :ref:`download-and-install-compass`.
 
 .. seealso::
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -122,7 +122,7 @@ Procedure
 
 .. note::
 
-   If you are running macOS Catalina, or later, you may have to modify
+   If you are running macOS Catalina, or later versions, you may have to modify
    your system settings to grant |compass-short| permission to run. For
    more information, see :ref:`compass-install`.
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -123,8 +123,9 @@ Procedure
 .. note::
 
    If you are running macOS Catalina, or later, you may have to modify
-   your system settings to grant |compass-short| permission to run. For more
-   information on how to grant access permission to |compass-short|, see :ref:`install-compass`.
+   your system settings to grant |compass-short| permission to run. For
+   more information on how to grant access permission to
+   |compass-short|, see :ref:`Install compass <install-compass>`.
 
 .. seealso::
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -124,8 +124,7 @@ Procedure
 
    If you are running macOS Catalina, or later, you may have to modify
    your system settings to grant |compass-short| permission to run. For
-   more information on how to grant access permission to
-   |compass-short|, see :ref:`compass-install`.
+   more information, see :ref:`compass-install`.
 
 .. seealso::
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -125,7 +125,8 @@ Procedure
    If you are running macOS Catalina, or later, you may have to modify
    your system settings to grant |compass-short| permission to run. For
    more information on how to grant access permission to
-   |compass-short|, see :ref:`install-compass`.
+   |compass-short|, see :ref:`compass-install`.
+
 .. seealso::
 
    :ref:`download-install`

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -124,7 +124,7 @@ Procedure
 
    If you are running macOS Catalina, or later, you may have to modify
    your system settings to grant Compass permission to run. For more
-   information on how to grant access permission to Compass, see :ref: `install-compass`.
+   information on how to grant access permission to Compass, see :ref:`install-compass`.
 
 .. seealso::
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -125,7 +125,7 @@ Procedure
    If you are running macOS Catalina, or later, you may have to modify
    your system settings to grant |compass-short| permission to run. For
    more information on how to grant access permission to
-   |compass-short|, see :ref:`install-compass`.
+   |compass-short|, see :ref:`compass-install-compass`.
 
 .. seealso::
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -125,7 +125,7 @@ Procedure
    If you are running macOS Catalina, or later, you may have to modify
    your system settings to grant |compass-short| permission to run. For
    more information on how to grant access permission to
-   |compass-short|, see :ref:`Download and Install Compass <download-and-install-compass>`.
+   |compass-short|, see :ref:`install-compass`.
 
 .. seealso::
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -120,6 +120,12 @@ Procedure
 
 #. Launch the fully-featured edition of |compass|.
 
+.. note::
+
+   If you are running macOS Catalina, or later, you may have to modify
+   your system settings to grant Compass permission to run. For more
+   information on how to grant access permission to Compass, see :ref: `install-compass`.
+
 .. seealso::
 
    :ref:`download-install`

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -123,8 +123,8 @@ Procedure
 .. note::
 
    If you are running macOS Catalina, or later, you may have to modify
-   your system settings to grant Compass permission to run. For more
-   information on how to grant access permission to Compass, see :ref:`install-compass`.
+   your system settings to grant |compass-short| permission to run. For more
+   information on how to grant access permission to |compass-short|, see :ref:`install-compass`.
 
 .. seealso::
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -125,7 +125,7 @@ Procedure
    If you are running macOS Catalina, or later, you may have to modify
    your system settings to grant |compass-short| permission to run. For
    more information on how to grant access permission to
-   |compass-short|, see :ref:`download-and-install-compass`
+   |compass-short|, see :ref:`install-compass`.
 .. seealso::
 
    :ref:`download-install`

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -125,7 +125,7 @@ Procedure
    If you are running macOS Catalina, or later, you may have to modify
    your system settings to grant |compass-short| permission to run. For
    more information on how to grant access permission to
-   |compass-short|, see :ref:`download-and-install-compass`.
+   |compass-short|, see :ref:`Download and Install Compass <download-and-install-compass>`.
 
 .. seealso::
 


### PR DESCRIPTION
Added note that Explain tab is not available for aggregation and referred users to .explain() method.

Jira: https://jira.mongodb.org/browse/DOCSP-11062

staging: https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker/DOCSP-11062/query-plan.html