### PR TITLE
(DOCSP-11197): Wildcard index clarifications

### DIFF
--- a/source/includes/steps-create-index.yaml
+++ b/source/includes/steps-create-index.yaml
@@ -1,14 +1,16 @@
 title: Click the :guilabel:`Create Index` button.
 level: 4
 ref: create-collection
+stepnum: 1
 content: |
-    From the :ref:`Indexes <collection-tab>` tab, click the
-    :guilabel:`Create Index` button to open the
+    From the :ref:`Indexes <collection-tab>` tab, click
+    :guilabel:`Create Index` to open the
     :guilabel:`Create Index` dialog.
 ---
 title: Optional. Enter the index name.
 level: 4
 ref: enter-index-name
+stepnum: 2
 content: |
    In the dialog, enter the name of the index to create, or leave blank
    to have MongoDB create a default name for the index.
@@ -16,26 +18,34 @@ content: |
 title: Add fields to index.
 level: 4
 ref: index-fields
+stepnum: 3
 content: |
-   To specify an existing document field as an index key, select the
-   field from the dropdown list.
 
-   To specify a field which does not exist in any document as an index
-   key, type the field name in the input box.
+   a. Specify an index key.
 
-   To create a :manual:`compound index </core/index-compound/>`, click
-   :guilabel:`Add Another Field`.
+      - To specify an existing document field as an index key, select
+        the field from the dropdown list.
 
-   Use the dropdown to the right of each field name to specify the index
-   type (``ascending``, ``descending``, or ``2dsphere``).
+      - To specify a field which does not exist in any document as an
+        index key, enter the field name in the input box.
 
-   To learn how to specify a wildcard index, see
-   :ref:`compass-wildcard-index`.
+      - To create a :manual:`compound index </core/index-compound/>`,
+        click :guilabel:`Add Another Field`.
+
+   b. Use the dropdown to the right of each field name to specify the
+      index type (``ascending``, ``descending``, or
+      :manual:`2dsphere </core/2dsphere/>`).
+
+   .. seealso::
+
+      To learn how to specify a wildcard index, see
+      :ref:`compass-wildcard-index`.
 
 ---
 title: Optional. Specify the index options.
 level: 4
 ref: index-options
+stepnum: 4
 content: |
 
    |compass-short| supports the following index options:
@@ -50,29 +60,28 @@ content: |
 
       * - Build index in the background
 
-        - If checked, ensure that the MongoDB deployment remains
-          available during the index build operation.
+        - Ensure that the MongoDB deployment remains available during
+          the index build operation.
 
         - :manual:`Background Construction </core/index-creation/index.html#background-construction>`
 
       * - Create unique index
 
-        - If checked, ensure that the indexed fields do not
-          store duplicate values.
+        - Ensure that the indexed fields do not store duplicate values.
 
         - :manual:`Unique Indexes </core/index-unique>`
 
       * - Create a :abbr:`TTL (Time to Live)` index
 
-        - If checked, automatically delete documents after a
-          specified number of seconds since the indexed field value.
+        - Automatically delete documents after a specified number of
+          seconds since the indexed field value.
 
         - :manual:`TTL Indexes </core/index-ttl>`
 
       * - Partial filter expression
       
-        - If checked, only index documents which match the specified
-          filter expression.
+        - Only index documents which match the specified filter
+          expression.
 
           .. example::
 
@@ -87,24 +96,22 @@ content: |
 
       * - Use custom collation
 
-        - If checked, create a custom collation for the index
-          using the options provided in |compass-short|.
+        - Create a custom collation for the index using the options
+          provided in |compass-short|.
 
         - :manual:`Collation Document </reference/collation/#collation-document>`
 
       * - Wildcard projection (*New in MongoDB 4.2*)
         
-        - If checked, support unknown or arbitrary fields
-          which match the specified projection in the index. You can
-          only specify a wildcard projection if your index field name is
-          ``$**``, meaning it covers all fields in the document.
+        - Support unknown or arbitrary fields which match the specified
+          projection in the index. To use a wildcard projection, set
+          your index field name to  ``$**``. This directs
+          |compass-short| to use all fields in the document (excluding
+          ``_id``).
 
           .. example::
 
-             If your index field name is ``$**``, the following
-             wildcard projection document only includes
-             the values of the ``product_attributes.elements`` and
-             ``product_attributes.resistance`` fields in the index:
+             Consider the following wildcard projection document:
 
              .. code-block:: javascript
 
@@ -113,10 +120,14 @@ content: |
                   "product_attributes.resistance" : 1
                 }
 
+             If your index field name is ``$**``, your index only
+             includes the values of the fields in that projection.
+
         - :ref:`compass-wildcard-index`
 ---
 title: Click :guilabel:`Create Index`.
 level: 4
 ref: create-index-button
+stepnum: 5
 content: ""
 ...

--- a/source/includes/steps-create-index.yaml
+++ b/source/includes/steps-create-index.yaml
@@ -3,7 +3,7 @@ level: 4
 ref: create-collection
 content: |
     From the :ref:`Indexes <collection-tab>` tab, click the
-    :guilabel:`Create Index` button to bring up the
+    :guilabel:`Create Index` button to open the
     :guilabel:`Create Index` dialog.
 ---
 title: Optional. Enter the index name.
@@ -17,8 +17,21 @@ title: Add fields to index.
 level: 4
 ref: index-fields
 content: |
-   To specify a key for the index, select the field and the index type.
-   To index additional fields, click :guilabel:`Add Another Field`.
+   To specify an existing document field as an index key, select the
+   field from the dropdown list.
+
+   To specify a field which does not exist in any document as an index
+   key, type the field name in the input box.
+
+   To create a :manual:`compound index </core/index-compound/>`, click
+   :guilabel:`Add Another Field`.
+
+   Use the dropdown to the right of each field name to specify the index
+   type (``ascending``, ``descending``, or ``2dsphere``).
+
+   To learn how to specify a wildcard index, see
+   :ref:`compass-wildcard-index`.
+
 ---
 title: Optional. Specify the index options.
 level: 4
@@ -49,7 +62,7 @@ content: |
 
         - :manual:`Unique Indexes </core/index-unique>`
 
-      * - Create :abbr:`TTL (Time to Live)`
+      * - Create a :abbr:`TTL (Time to Live)` index
 
         - If checked, automatically delete documents after a
           specified number of seconds since the indexed field value.
@@ -82,11 +95,27 @@ content: |
       * - Wildcard projection (*New in MongoDB 4.2*)
         
         - If checked, support unknown or arbitrary fields
-          which match the specified projection in the index.
+          which match the specified projection in the index. You can
+          only specify a wildcard projection if your index field name is
+          ``$**``, meaning it covers all fields in the document.
 
-        - :manual-next:`Wildcard Indexes </core/index-wildcard/>`
+          .. example::
+
+             If your index field name is ``$**``, the following
+             wildcard projection document only includes
+             the values of the ``product_attributes.elements`` and
+             ``product_attributes.resistance`` fields in the index:
+
+             .. code-block:: javascript
+
+                {
+                  "product_attributes.elements" : 1,
+                  "product_attributes.resistance" : 1
+                }
+
+        - :ref:`compass-wildcard-index`
 ---
-title: Click :guilabel:`Create` to create the index.
+title: Click :guilabel:`Create Index`.
 level: 4
 ref: create-index-button
 content: ""

--- a/source/includes/steps-create-index.yaml
+++ b/source/includes/steps-create-index.yaml
@@ -73,14 +73,14 @@ content: |
 
       * - Create a :abbr:`TTL (Time to Live)` index
 
-        - Automatically delete documents after a specified number of
+        - Delete documents automatically after a specified number of
           seconds since the indexed field value.
 
         - :manual:`TTL Indexes </core/index-ttl>`
 
       * - Partial filter expression
       
-        - Only index documents which match the specified filter
+        - Index only the documents which match the specified filter
           expression.
 
           .. example::

--- a/source/indexes.txt
+++ b/source/indexes.txt
@@ -100,7 +100,7 @@ support queries against unknown or arbitrary fields.
    between documents.
 
    You can create a wildcard index on ``userMetadata`` to account for
-   all potential fields within the object. In |compass-short|, type
+   all potential fields within the object. In |compass-short|, enter
    the following for the index name:
 
    .. code-block:: javascript

--- a/source/indexes.txt
+++ b/source/indexes.txt
@@ -83,6 +83,36 @@ contain documents.
 
 .. include:: /includes/steps/create-index.rst
 
+.. _compass-wildcard-index:
+
+Wildcard Indexes
+~~~~~~~~~~~~~~~~
+
+.. versionadded:: v4.2
+
+You can create :manual:`wildcard indexes </core/index-wildcard/>` to
+support queries against unknown or arbitrary fields.
+
+.. example::
+
+   Consider a collection where documents contain a ``userMetadata``
+   object. The fields within the ``userMetadata`` object may vary
+   between documents.
+
+   You can create a wildcard index on ``userMetadata`` to account for
+   all potential fields within the object. In |compass-short|, type
+   the following for the index name:
+
+   .. code-block:: javascript
+
+      userMetadata.$**
+
+   Specify a type (``ascending`` or ``descending``) for your wildcard
+   index, then click :guilabel:`Create Index`.
+
+   |compass-short| shows the type of your new index as
+   :guilabel:`Wildcard`.
+
 .. _drop-index:
 
 Drop an Index


### PR DESCRIPTION
Creating wildcard indexes is not very intuitive in Compass. This attempts to clarify the process a bit by adding more detail and examples.

Staged: [Manage Indexes](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-11197/indexes.html#create-an-index)