### PR TITLE
(DOCSP-11872): Add limitation for updating sharded collection

### DIFF
--- a/source/documents/modify.txt
+++ b/source/documents/modify.txt
@@ -6,15 +6,28 @@ Modify Documents
 
 .. default-domain:: mongodb
 
-.. important::
-
-   Modifying documents is not permitted in
-   :guilabel:`MongoDB Compass Readonly Edition`.
-
 You can edit existing documents in your collection. When you edit
 a document, |compass-short| performs a
 :manual:`findAndModify </reference/method/db.collection.findAndModify/>`
 operation to update the document.
+
+Limitations
+-----------
+
+- Modifying documents is not permitted in
+  :guilabel:`MongoDB Compass Readonly Edition`.
+
+- You cannot use the |compass| :abbr:`GUI (Graphical User Interface)` to
+  modify documents in a :manual:`sharded collection </sharding>`. As an
+  alternative, you can use the
+  :ref:`Embedded MongoDB Shell <embedded-mongodb-shell>` in
+  |compass-short| to modify a sharded collection. To learn more
+  about updates on sharded collections, see
+  :manual:`Sharded Collection Behavior
+  </reference/method/db.collection.update/#update-sharded-collection>`.
+
+Procedure
+---------
 
 Select the appropriate tab based on whether you are viewing your
 documents in List, JSON, or Table view:


### PR DESCRIPTION
Consolidated the Read-only limitation and this new limitation to a new `Limitations` section at the top of the page.

See staging: [Modify Documents](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-11872/documents/modify.html)