### PR TITLE
(DOCSP-12925): Refactor Linux Install

### DIFF
--- a/source/install.txt
+++ b/source/install.txt
@@ -12,14 +12,14 @@ Select your operating system:
 
 .. _software-reqs:
 
-Software Requirements
----------------------
-
 .. tabs-platforms::
 
    tabs:
      - id: macos
        content: |
+
+         Software Requirements
+         ---------------------
 
          |compass-short| requires:
 
@@ -28,6 +28,9 @@ Software Requirements
 
      - id: windows
        content: |
+
+         Software Requirements
+         ---------------------
 
          |compass-short| requires:
 
@@ -42,34 +45,50 @@ Software Requirements
      - id: linux
        content: |
 
+         Select the appropriate tab based on your Linux distribution and
+         desired package from the tabs below:
+
+         - To install the ``.deb`` package on Ubuntu and Debian,
+           click the ``.deb`` tab.
+         
+         - To install the ``.rpm`` package on
+           :abbr:`RHEL (Red Hat Enterprise Linux)`, click the ``.rpm``
+           tab.
+
          .. tabs::
 
-            .. tab:: Debian
+            .. tab:: .deb
                :tabid: debian
+
+               Software Requirements
+               ---------------------
 
                |compass-short| requires:
 
                - 64-bit version of Ubuntu 14.04 or later.
                - MongoDB 3.6 or later.
 
-            .. tab:: RHEL
+            .. tab:: .rpm
                :tabid: rhel
+
+               Software Requirements
+               ---------------------
 
                |compass-short| requires:
 
                - 64-bit version of RHEL 7+ or later.
                - MongoDB 3.6 or later.
 
-Download Compass
-----------------
-
-To download |compass-short|, you can use your preferred web browser.
-
 .. tabs-platforms::
    :hidden:
 
    .. tab::
       :tabid: macos
+
+      Download Compass
+      ----------------
+
+      To download |compass-short|, you can use your preferred web browser.
 
       1. Open the {+download-page+}.
 
@@ -79,6 +98,11 @@ To download |compass-short|, you can use your preferred web browser.
 
    .. tab::
       :tabid: windows
+
+      Download Compass
+      ----------------
+
+      To download |compass-short|, you can use your preferred web browser.
 
       1. Open the {+download-page+}.
 
@@ -92,37 +116,73 @@ To download |compass-short|, you can use your preferred web browser.
    .. tab::
       :tabid: linux
 
+      Download and Install Compass
+      ----------------------------
+
+      To download |compass-short| on Linux systems, use ``wget``.
+
+      .. note::
+
+         Alternatively, you can download |compass-short| from the
+         {+download-page+}.
+
       .. tabs::
          :hidden:
 
          .. tab:: Debian
             :tabid: debian
 
-            1. Open the {+download-page+}.
+            1. Download |compass|
 
-            #. Download the latest version of |compass| for
-               Ubuntu. The |compass| installer is a ``.deb``
-               package.
+               .. code-block:: shell
+
+                  wget https://downloads.mongodb.com/compass/mongodb-compass_{+current-version+}_amd64.deb
+               
+
+            #. Install |compass|
+
+               .. code-block:: shell
+
+                  sudo dpkg -i mongodb-compass_{+current-version+}_amd64.deb
+
+            #. Start |compass|
+
+               .. code-block:: sh
+
+                  mongodb-compass
 
          .. tab:: RHEL
             :tabid: rhel
 
-            1. Open the {+download-page+}.
+            1. Download |compass|
 
-            #. Download the latest version of |compass| for Red Hat
-               Enterprise Linux. The |compass| installer is a
-               ``.rpm`` package.
+               .. code-block:: shell
+
+                  wget https://downloads.mongodb.com/compass/mongodb-compass-{+current-version+}.x86_64.rpm
+               
+
+            #. Install |compass|
+
+               .. code-block:: shell
+
+                  sudo yum install mongodb-compass-1.22.1.x86_64.rpm
+
+            #. Start |compass|
+
+               .. code-block:: sh
+
+                  mongodb-compass
 
 .. _compass-install:
-
-Install Compass
----------------
 
 .. tabs-platforms::
    :hidden:
 
    .. tab::
       :tabid: macos
+
+      Install Compass
+      ---------------
 
       1. Once you have downloaded |compass-short|, double-click on
          the ``.dmg`` file to open the disk image within the macOS
@@ -155,6 +215,9 @@ Install Compass
    .. tab::
       :tabid: windows
 
+      Install Compass
+      ---------------
+
       1. Double-click the installer file.
 
       #. Follow the prompts to install |compass-short|. You can
@@ -162,47 +225,6 @@ Install Compass
 
       #. Once installed, |compass-short| launches and prompts you to
          configure privacy settings and specify update preferences.
-
-   .. tab::
-      :tabid: linux
-
-      .. tabs::
-         :hidden:
-
-         .. tab:: Debian
-            :tabid: debian
-
-            1. Double-click on the ``.deb`` package icon to start
-               installation.
-
-            #. Click :guilabel:`Install`.
-
-               .. figure:: /images/compass/install-ubuntu.png
-                  :figwidth: 654px
-
-            #. Once installed, launch Compass from your
-               :guilabel:`Applications` folder.
-
-            #. Start Compass:
-
-               .. code-block:: sh
-
-                  mongodb-compass
-
-         .. tab:: RHEL
-            :tabid: rhel
-
-            #. Install Compass:
-
-               .. code-block:: sh
-
-                  sudo yum install mongodb-compass-{+current-version+}.x86_64.rpm
-
-            #. Start Compass:
-
-               .. code-block:: sh
-
-                  mongodb-compass
 
 .. seealso::
 

--- a/source/install.txt
+++ b/source/install.txt
@@ -124,7 +124,7 @@ Select your operating system:
       .. note::
 
          Alternatively, you can download |compass-short| from the
-         {+download-page+}.
+         MongoDB {+download-page+}.
 
       .. tabs::
          :hidden:


### PR DESCRIPTION
These changes were made in light of [DOCSP-12925](https://jira.mongodb.org/browse/DOCSP-12925). Please see my comment on that ticket and let me know if there is anything specific we need to address for Ubuntu 20.04.

The changes here update the Linux install experience to be terminal-only (using `wget`), as opposed to navigating to Download Center

Staging: https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-12925/install