### PR TITLE
(DOCSP-13518) X509 username field is optional

### DIFF
--- a/source/includes/steps-starting-compass-individual-fields.yaml
+++ b/source/includes/steps-starting-compass-individual-fields.yaml
@@ -233,6 +233,12 @@ content: |
                     from the X.509 certificate. In most most cases, you 
                     do not need to provide the :guilabel:`Username`.
 
+                    If you are using 
+                    :atlas:`Atlas-managed certificates </security-add-mongodb-users/#select-an-authentication-method>`
+                    , your username must be prefaced by "CN="
+                    per :rfc:`2253`. For example, the username 
+                    "X509User" must be provided as "CN=X509User".
+
      * - :guilabel:`Favorite Name`
        - *Optional*. A name for the connection. To save the current
          connection entered as a

--- a/source/includes/steps-starting-compass-individual-fields.yaml
+++ b/source/includes/steps-starting-compass-individual-fields.yaml
@@ -222,17 +222,7 @@ content: |
 
                  Select :guilabel:`X.509` if the deployment uses
                  :manual:`X.509 </core/security-x.509/>` as its
-                 authentication mechanism. If selected, you must
-                 provide the  :guilabel:`Username` to authenticate
-                 the user.
-
-                 .. note::
-
-                    If you are using 
-                    :atlas:`Atlas-managed certificates </security-add-mongodb-users/#select-an-authentication-method>`
-                    , your username must be prefaced by "CN="
-                    per :rfc:`2253`. For example, the username 
-                    "X509User" must be provided as "CN=X509User".
+                 authentication mechanism. 
 
      * - :guilabel:`Favorite Name`
        - *Optional*. A name for the connection. To save the current

--- a/source/includes/steps-starting-compass-individual-fields.yaml
+++ b/source/includes/steps-starting-compass-individual-fields.yaml
@@ -224,6 +224,15 @@ content: |
                  :manual:`X.509 </core/security-x.509/>` as its
                  authentication mechanism. 
 
+                 If selected, you may optionally provide the 
+                 :guilabel:`Username` to authenticate the user.
+                 
+                 .. note::
+
+                    |compass-short| retrieves the username
+                    from the X.509 certificate. In most most cases, you 
+                    do not need to provide the :guilabel:`Username`.
+
      * - :guilabel:`Favorite Name`
        - *Optional*. A name for the connection. To save the current
          connection entered as a


### PR DESCRIPTION
[Jira](https://jira.mongodb.org/browse/DOCSP-13518)
[Staged: Fill in Individual Fields > step 2 > Authentication > X.509 tab](https://docs-mongodbcom-staging.corp.mongodb.com/compass/zach.carr/DOCSP-13518/connect.html)

Providing a Username is now essentially optional - it gets pulled from the X.509 cert. 

However, in some cases where a user has generated their own X.509 cert, they may still need to supply the username. This sounds like an edge case and I'm not sure how much we should highlight that. I added a note that aims to reassure users who aren't entering the Username and give users who run into errors a clue as to what went wrong. 