### PR TITLE
(DOCSP-14430): Removed references about completing the username field for x.509 authentication.

### DIFF
--- a/source/includes/steps-starting-compass-individual-fields.yaml
+++ b/source/includes/steps-starting-compass-individual-fields.yaml
@@ -219,21 +219,11 @@ content: |
                  Select :guilabel:`X.509` if the deployment uses
                  :manual:`X.509 </core/security-x.509/>` as its
                  authentication mechanism. 
-
-                 If selected, you may optionally provide the 
-                 :guilabel:`Username` to authenticate the user.
                  
                  .. note::
 
                     |compass-short| retrieves the username
-                    from the X.509 certificate. In most most cases, you 
-                    do not need to provide the :guilabel:`Username`.
-
-                    If you are using 
-                    :atlas:`Atlas-managed certificates </security-add-mongodb-users/#select-an-authentication-method>`
-                    , your username must be prefaced by "CN="
-                    per :rfc:`2253`. For example, the username 
-                    "X509User" must be provided as "CN=X509User".
+                    from the X.509 certificate.
 
      * - :guilabel:`Favorite Name`
        - *Optional*. A name for the connection. To save the current


### PR DESCRIPTION
@mongomoe, I removed references about completing the username field for x.509 authentication from the following page (Select the Fill in Individual Fields tab, see step 2, Authentication, and then the X.509 tab.):

[STAGE](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-14430/connect/#enter-your-connection-information)

[JIRA](https://jira.mongodb.org/browse/DOCSP-14430)

[BUILD](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=602c1ed7ab23346c20cac698)