### PR TITLE
(DOCSP-14727) Remove limitation that you cannot use the UI to make updates in sharded collections

### DIFF
--- a/source/documents/modify.txt
+++ b/source/documents/modify.txt
@@ -19,15 +19,6 @@ Limitations
 - Modifying documents is not permitted in
   :guilabel:`MongoDB Compass Readonly Edition`.
 
-- You cannot use the |compass| :abbr:`GUI (Graphical User Interface)` to
-  modify documents in a :manual:`sharded collection </sharding>`. As an
-  alternative, you can use the
-  :ref:`Embedded MongoDB Shell <embedded-mongodb-shell>` in
-  |compass-short| to modify a sharded collection. To learn more
-  about updates on sharded collections, see
-  :manual:`Sharded Collection Behavior
-  </reference/method/db.collection.update/#update-sharded-collection>`.
-
 Procedure
 ---------
 


### PR DESCRIPTION
[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=603455b2ab23346c203b34a1) has no issues.
[Jira](https://jira.mongodb.org/browse/DOCSP-14727) asked to remove the limitation. 

[Staging shows only one bullet in limitations](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-14727/documents/modify/), instead of [two limitations in the current topic](https://docs.mongodb.com/compass/current/documents/modify).

Please let me know if I can skip tech review for this one!

