### PR TITLE
DOP-1883: use canonical links for redirects

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1,12 +1,10 @@
 define: base https://docs.mongodb.com/compass
 define: versions master beta
 
-symlink: current -> master
-
 raw: compass/beta-features -> ${base}/
 raw: compass/1.3-features -> ${base}/
-raw: compass/index.html -> ${base}/current
-raw: compass/ -> ${base}/current
-raw: compass/manual/aggregation-pipeline-builder -> ${base}/current/aggregation-pipeline-builder
+raw: compass/index.html -> ${base}/current/
+raw: compass/ -> ${base}/current/
+raw: compass/manual/aggregation-pipeline-builder -> ${base}/current/aggregation-pipeline-builder/
 
 [master-beta]: compass/${version}/query-bar -> ${base}/${version}/query/filter/


### PR DESCRIPTION
Updating redirects to use the canonical URL and thus remove some redirect steps. This is part of the high-priority SEO work. Also removed the symlink that has no meaning in Snooty.

Produced redirect file:

```
Redirect 301 /compass/beta-features https://docs.mongodb.com/compass/
Redirect 301 /compass/1.3-features https://docs.mongodb.com/compass/
Redirect 301 /compass/index.html https://docs.mongodb.com/compass/current/
Redirect 301 /compass/ https://docs.mongodb.com/compass/current/
Redirect 301 /compass/manual/aggregation-pipeline-builder https://docs.mongodb.com/compass/current/aggregation-pipeline-builder/
Redirect 301 /compass/master/query-bar https://docs.mongodb.com/compass/master/query/filter/
Redirect 301 /compass/beta/query-bar https://docs.mongodb.com/compass/beta/query/filter/
```