### PR TITLE
Fixing formatting issues introduced and missed by prev PR

### DIFF
--- a/source/aggregation-pipeline-builder.txt
+++ b/source/aggregation-pipeline-builder.txt
@@ -14,7 +14,8 @@ Aggregation Pipeline Builder
 
 *New in version 1.14.0*
 
-Create :manual:`aggregation pipelines </core/aggregation-pipeline/>` to
+The Aggregation Pipeline Builder in |compass| provides the ability to
+create :manual:`aggregation pipelines </core/aggregation-pipeline/>` to
 process data. In aggregation pipelines, documents in a collection
 or view pass through stages where |compass| processes them into a
 set of aggregated results. You can change the stages and results to
@@ -182,9 +183,9 @@ Create a View from Pipeline Results
    Creating a view from pipeline results does not save the pipeline
    itself.
 
-   To create a view from your pipeline results:
+To create a view from your pipeline results:
 
-   .. include:: /includes/fact-create-view-from-pipeline.rst
+.. include:: /includes/fact-create-view-from-pipeline.rst
 
 Example
 -------


### PR DESCRIPTION
Fixing an indentation issue and restoring an intro sentence.  All are fixes for missed issues in #345. No need to review as no changes introduced, just formatting issues fixed. 
[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=608b396409293ae626ee6a0a) is clean.
