### PR TITLE
DOCSP-20458 directConnection=true must now be declared

### DIFF
--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -10,6 +10,14 @@ Release Notes
    :depth: 1
    :class: twocols
 
+|compass| 1.31.0
+----------------
+
+Bug Fixes:
+
+- 
+
+
 |compass| 1.30.1
 ----------------
 

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -15,7 +15,8 @@ Release Notes
 
 Bug Fixes:
 
-- 
+- Does not automatically set ``directConnection = true``. User must explicitly
+  declare ``directConnection = true``. 
 
 
 |compass| 1.30.1

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -15,8 +15,8 @@ Release Notes
 
 Bug Fixes:
 
-- Does not automatically set ``directConnection = true``. User must explicitly
-  declare ``directConnection = true``. 
+- Does not automatically set ``directConnection=true``. User must explicitly
+  declare ``directConnection=true``. 
 
 
 |compass| 1.30.1

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -18,7 +18,6 @@ Bug Fixes:
 - Does not automatically set ``directConnection=true``. User must explicitly
   declare ``directConnection=true``. 
 
-
 |compass| 1.30.1
 ----------------
 

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -15,7 +15,7 @@ Release Notes
 
 Bug Fixes:
 
-- Does not automatically set ``directConnection=true``. User must explicitly
+- Does not automatically set ``directConnection=true``. You must explicitly
   declare ``directConnection=true``. 
 
 |compass| 1.30.1


### PR DESCRIPTION
Compass no longer automatically sets directConnection=true and now user must declare it explicitly.

JIRA: https://jira.mongodb.org/browse/DOCSP-20458?filter=-1

STAGING:  https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-20458/release-notes/