### PR TITLE
DOCSP-20400 replica sets can connect using Socks5 (#372)

### DIFF
--- a/source/includes/steps-starting-compass-individual-fields.yaml
+++ b/source/includes/steps-starting-compass-individual-fields.yaml
@@ -430,12 +430,6 @@ content: |
            the :binary:`~bin.mongo` shell) to ``localhost:27000`` to
            connect to the deployment running on
            ``hostname-a.com``.
-
-        .. note::
-
-           You cannot connect to a :term:`replica set` via an SSH
-           tunnel. |compass-short| cannot establish a connection
-           to multiple servers across the same SSH tunnel.
 ---
 title: Connect.
 level: 4

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -42,7 +42,8 @@ Bug Fixes:
 
 - BSON Transpilers: Account for bson Decimal128 validation changes.
 
-- Make SSH tunnel use Socks5.
+- Make SSH tunnel use Socks5. You can now connect to replica sets and 
+  sharded clusters using an SSH tunnel.
 
 - Compass Logging: Bump mongodb-log-writer to allow browser envs.
 


### PR DESCRIPTION
* DOCSP-20400 replica sets can connect using Socks5

* DOCSP-20400 replica sets can connect using Socks5

* DOCSP-20400 replica sets connect using ssh tunnel

* DOCSP-20400 replica set and shared clusters can connect using SSH tunnel

* DOCSP-20400 replica set and shared clusters can connect using SSH tunnel

* DOCSP-20400 fixed typo

Co-authored-by: Jocelyn Mendez <jocelyn.mendez@Jocelyns-MacBook-Pro.local>