### PR TITLE
(DOCSP-18928): Compass logs

### DIFF
--- a/source/faq.txt
+++ b/source/faq.txt
@@ -51,6 +51,17 @@ data in the operating system's credentials API. For more information on
 how Keytar operates and the specific APIs it accesses, refer to the
 `Keytar Github documentation <https://github.com/atom/node-keytar>`_.
 
+.. _compass-faq-logs:
+
+Where can I find Compass logs?
+------------------------------
+
+As part of normal operation, |compass| maintains a running log of
+events. |compass-short| logs provide a history of operations and can
+help diagnose errors.
+
+For more information, see :ref:`compass-logs`.
+
 .. _compass-faq-non-genuine:
 
 Why am I seeing a warning about a non-genuine MongoDB server?
@@ -143,4 +154,3 @@ selected, |compass| is allowed to make requests to a third-party
 mapping service.
 
 .. include:: /includes/fact-isolated-ver-third-party-mapping.rst
-

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -53,12 +53,13 @@ how Keytar operates and the specific APIs it accesses, refer to the
 
 .. _compass-faq-logs:
 
-Where can I find Compass logs?
-------------------------------
+Does Compass Maintain Logs?
+---------------------------
 
 As part of normal operation, |compass| maintains a running log of
 events. |compass-short| logs provide a history of operations and can
-help diagnose errors. For more information, see :ref:`compass-logs`.
+help diagnose errors. For more information on |compass-short| logs,
+including their format and location, see :ref:`compass-logs`.
 
 .. _compass-faq-non-genuine:
 

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -58,9 +58,7 @@ Where can I find Compass logs?
 
 As part of normal operation, |compass| maintains a running log of
 events. |compass-short| logs provide a history of operations and can
-help diagnose errors.
-
-For more information, see :ref:`compass-logs`.
+help diagnose errors. For more information, see :ref:`compass-logs`.
 
 .. _compass-faq-non-genuine:
 

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -135,7 +135,7 @@ Bug Fixes:
 
 New Features:
 
-- Introduces :ref:`client-side logging <compass-logs>` for |compass|
+- Adds :ref:`client-side logging <compass-logs>` for |compass|
   operations.
 
 - Improved |compass| startup time.

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -135,6 +135,9 @@ Bug Fixes:
 
 New Features:
 
+- Introduces :ref:`client-side logging <compass-logs>` for |compass|
+  operations.
+
 - Improved |compass| startup time.
 
 - Adds support for `MongoDB 5.1 features

--- a/source/troubleshooting.txt
+++ b/source/troubleshooting.txt
@@ -7,6 +7,9 @@ Troubleshooting
 This section provides advice for troubleshooting problems with
 |compass|.
 
+:doc:`/troubleshooting/logs`
+  Retrieve |compass| logs to diagnose errors.
+
 :doc:`Connection Errors </troubleshooting/connection-errors>`
   Resolve issues with connecting |compass| to the MongoDB server.
 
@@ -15,4 +18,6 @@ This section provides advice for troubleshooting problems with
 .. toctree::
    :titlesonly:
 
+   /troubleshooting/logs
    /troubleshooting/connection-errors
+   

--- a/source/troubleshooting/connection-errors.txt
+++ b/source/troubleshooting/connection-errors.txt
@@ -342,9 +342,7 @@ Check the Compass Logs
 
 The |compass-short| logs can provide additional information on
 connection errors. You may find more detailed error messages to help
-diagnose your issue.
-
-To learn more, see :ref:`compass-logs`.
+diagnose your issue. For more information, see :ref:`compass-logs`.
 
 Additional Resources
 --------------------

--- a/source/troubleshooting/connection-errors.txt
+++ b/source/troubleshooting/connection-errors.txt
@@ -10,6 +10,9 @@ Compass Connection Errors
    :depth: 1
    :class: singlecol
 
+The sections on this page list common errors seen when connecting to
+|compass| and provide possible solutions.
+
 MongoDB Not Running on the Provided Host and Port
 -------------------------------------------------
 
@@ -333,6 +336,15 @@ Solutions
 
 - Verify that your selected authentication mechanism is supported by
   your MongoDB database.
+
+Check the Compass Logs
+----------------------
+
+The |compass-short| logs can provide additional information on
+connection errors. You may find more detailed error messages to help
+diagnose your issue.
+
+To learn more, see :ref:`compass-logs`.
 
 Additional Resources
 --------------------

--- a/source/troubleshooting/logs.txt
+++ b/source/troubleshooting/logs.txt
@@ -45,9 +45,12 @@ View Compass Logs
 Compass Log Location
 --------------------
 
-|compass-short| maintains one log file per session. The corresponding
-session ID is included in the log file name. The directory where
-|compass-short| writes logs depends on your operating system.
+|compass-short| maintains one log file per session, compressed into a
+gzip archive file. The corresponding session ID is included in the log
+file name.
+
+The directory where |compass-short| writes logs depends on your
+operating system.
 
 .. list-table::
    :header-rows: 1
@@ -57,11 +60,11 @@ session ID is included in the log file name. The directory where
    * - Operating System
      - Directory
    * - macOS
-     - ``~/.mongodb/compass/<LogID>_log``
+     - ``~/.mongodb/compass/<LogID>_log.gz``
    * - Linux
-     - ``~/.mongodb/compass/<LogID>_log``
+     - ``~/.mongodb/compass/<LogID>_log.gz``
    * - Windows
-     - ``%UserProfile%/AppData/Local/mongodb/compass/<LogID>_log``
+     - ``%UserProfile%/AppData/Local/mongodb/compass/<LogID>_log.gz``
 
 Log File Format
 ---------------

--- a/source/troubleshooting/logs.txt
+++ b/source/troubleshooting/logs.txt
@@ -23,14 +23,12 @@ help diagnose errors.
 View Compass Logs
 -----------------
 
-To view |compass-short| logs:
-
 .. procedure::
    :style: normal
 
    .. step:: In the |compass-short| top menu bar, click :guilabel:`Help`.
 
-   .. step:: Click :guilabel:`Open Log File`.
+   .. step:: In the :guilabel:`Help` menu, click :guilabel:`Open Log File`.
 
       |compass-short| opens a dialog containing the location of your log file.
 
@@ -38,7 +36,7 @@ To view |compass-short| logs:
 
       You can either:
 
-      - Copy the path to the log file.
+      - Copy the path to the log file to your clipboard.
 
       - Open the folder containing your log file.
 
@@ -47,8 +45,9 @@ To view |compass-short| logs:
 Compass Log Location
 --------------------
 
-The directory where |compass-short| writes logs depends on your
-operating system.
+|compass-short| maintains one log file per session. The corresponding
+session ID is included in the log file name. The directory where
+|compass-short| writes logs depends on your operating system.
 
 .. list-table::
    :header-rows: 1
@@ -68,10 +67,7 @@ Log File Format
 ---------------
 
 |compass-short| outputs log messages in structured JSON format. The
-messages are output in the same format used for MongoDB server logs.
-
-|compass-short| maintains one log file per session. The corresponding
-session ID is included in the log file name.
+messages are written in the same format used for MongoDB server logs.
 
 .. seealso::
 

--- a/source/troubleshooting/logs.txt
+++ b/source/troubleshooting/logs.txt
@@ -1,0 +1,85 @@
+.. _compass-logs:
+
+=====================
+Retrieve Compass Logs
+=====================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+As part of normal operation, |compass| maintains a running log of
+events. |compass-short| logs provide a history of operations and can
+help diagnose errors.
+
+.. note::
+
+   |compass| redacts credentials from the logs.
+
+View Compass Logs
+-----------------
+
+To view |compass-short| logs:
+
+.. procedure::
+   :style: normal
+
+   .. step:: In the |compass-short| top menu bar, click :guilabel:`Help`.
+
+   .. step:: Click :guilabel:`Open Log File`.
+
+      |compass-short| opens a dialog containing the location of your log file.
+
+   .. step:: Choose how to open the log file.
+
+      You can either:
+
+      - Copy the path to the log file.
+
+      - Open the folder containing your log file.
+
+      - Extract the log file and view it as a text file.
+
+Compass Log Location
+--------------------
+
+The directory where |compass-short| writes logs depends on your
+operating system.
+
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+   :widths: 10 20
+
+   * - Operating System
+     - Directory
+   * - macOS
+     - ``~/.mongodb/compass/<LogID>_log``
+   * - Linux
+     - ``~/.mongodb/compass/<LogID>_log``
+   * - Windows
+     - ``%UserProfile%/AppData/Local/mongodb/compass/<LogID>_log``
+
+Log File Format
+---------------
+
+|compass-short| outputs log messages in structured JSON format. The
+messages are output in the same format used for MongoDB server logs.
+
+|compass-short| maintains one log file per session. The corresponding
+session ID is included in the log file name.
+
+.. seealso::
+
+   To learn more about MongoDB logs and see examples, see
+   :ref:`log-messages-ref`.
+
+Log Retention
+-------------
+
+|compass-short| retains log files for 30 days. Log files older than 30
+days are automatically deleted.


### PR DESCRIPTION
### Description

This was a feature introduced a while ago that we missed documenting. As noted in [DOCSP-21469](https://jira.mongodb.org/browse/DOCSP-21469), in addition to creating a main page for logging, we also want to update the Troubleshooting, FAQ, and Release Notes for this feature.

### Staging Links

- [Retrieve Compass Logs](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-18928/troubleshooting/logs/)
- [New FAQ Item](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-18928/faq/#where-can-i-find-compass-logs-)
- [Connection Troubleshooting](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-18928/troubleshooting/connection-errors/#check-the-compass-logs)
- [1.29.4 Release Notes](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-18928/release-notes/#compass-1.29.4)

### JIRA

- [DOCSP-18928](https://jira.mongodb.org/browse/DOCSP-18928)
- [DOCSP-21469](https://jira.mongodb.org/browse/DOCSP-21469)

