### PR TITLE
DOCSP-21808 Connection string can be copied from Compass

### DIFF
--- a/source/includes/steps-starting-compass-paste-string.yaml
+++ b/source/includes/steps-starting-compass-paste-string.yaml
@@ -13,7 +13,7 @@ content: |
   - To obtain the connection string from a recently used |compass-short| 
     deployment:
 
-    a. Open |compass-short| and view list of :guilabel:`Recent` connections 
+    a. Open |compass-short| and view the list of :guilabel:`Recent` connections 
        on the left panel.
     
     #. Click the :icon-fa5:`ellipsis-h` next to the desired connection.

--- a/source/includes/steps-starting-compass-paste-string.yaml
+++ b/source/includes/steps-starting-compass-paste-string.yaml
@@ -10,6 +10,16 @@ content: |
   or the :manual:`DNS Seedlist Connection Format
   </reference/connection-string/#connections-dns-seedlist>`.
 
+  - To obtain the connection string from a recently used |compass-short| 
+    deployment:
+
+    a. Open |compass-short| and view list of :guilabel:`Recent` connections 
+       on the left panel.
+    
+    #. Click the :icon-fa5:`ellipsis-h` next to the desired connection.
+
+    #. Click :guilabel:`Copy Connection String`.
+
   - To obtain the connection string for an |service| cluster:
   
     a. Navigate to your |service| :guilabel:`Clusters` view.


### PR DESCRIPTION
Connection string can be copied from recently used databases. Updated Paste Connection String section to reflect that. 

JIRA: https://jira.mongodb.org/browse/DOCSP-21808?filter=-3

STAGING: https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-21808/connect/#paste-connection-string