### PR TITLE
DOCSP-22723 fix broken link

### DIFF
--- a/source/includes/fact-release-notes-1.11.rst
+++ b/source/includes/fact-release-notes-1.11.rst
@@ -1,7 +1,7 @@
 - Added support for plugins
   that extend the functionality of |compass|.
 
-- Added support for :ref:`disconnecting <disconnect>` from the active
+- Added support for :ref:`disconnecting <disconnect-tab>` from the active
   MongoDB instance without restarting |compass|.
 
 - Added :ref:`Table View <docs-list-table-view>` for documents as a

--- a/source/indexes.txt
+++ b/source/indexes.txt
@@ -35,7 +35,7 @@ To learn more about indexes, see :manual:`Indexes </indexes>`.
    For collections with high write-to-read ratio, indexes are expensive 
    since each insert must also update any indexes. For a detailed list 
    of considerations for indexes, see
-   :manual:`Operational Considerations for Indexes <core/data-model-operations/#data-model-indexes>`.
+   :ref:`Operational Considerations for Indexes <data-model-indexes>`.
 
 .. _indexes-tab:
 


### PR DESCRIPTION
[STAGING](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-22723-fix-brokewn-link-v6.0/indexes/#indexes-tab)  - just above this point

[staging - build error](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-22723-fix-brokewn-link-v6.0/release-notes/#compass-1.11)

[JIRA](https://jira.mongodb.org/browse/DOCSP-22723)

Also fixes an existing build error
