### PR TITLE
(DOCSP-23128): Compass 1.32.1 and 1.32.2 release notes

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -12,7 +12,7 @@ toc_landing_pages = ["/install", "/connect", "/instance", "/query/filter", "/que
 
 [constants]
 download-page = "`downloads page <https://www.mongodb.com/download-center/compass?tck=docs_compass>`__"
-current-version = "1.32.0"
+current-version = "1.32.2"
 
 
 [substitutions]

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -10,6 +10,38 @@ Release Notes
    :depth: 1
    :class: twocols
 
+|compass| 1.32.2
+----------------
+
+*Released June 7, 2022*
+
+Fixes an issue where ``$out`` and ``$merge`` aggregation stages would
+not appear when connected to a :atlas:`Data Lake </data-lake>`.
+
+`Full changelog available on GitHub
+<https://github.com/mongodb-js/compass/releases/tag/v1.32.2>`__.
+
+|compass| 1.32.1
+----------------
+
+*Released June 3, 2022*
+
+New Features:
+
+- Enables In-Use Encryption (:issue:`COMPASS-5634`)
+
+- Show index keys in aggregation explain plan (:issue:`COMPASS-5857`)
+
+Bug Fixes:
+
+- Open aggregation pipeline in correct namespace (:issue:`COMPASS-5872`)
+
+- Hide ``$documents`` operator in collection aggregations
+  (:issue:`COMPASS-5843`)
+
+`Full changelog available on GitHub
+<https://github.com/mongodb-js/compass/releases/tag/v1.32.1>`__.
+
 |compass| 1.32.0
 ----------------
 

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -15,7 +15,7 @@ Release Notes
 
 *Released June 7, 2022*
 
-Fixes an issue where ``$out`` and ``$merge`` aggregation stages would
+Fixes an issue where ``$merge`` and ``$out`` aggregation stages would
 not appear in the pipeline builder when connected to a :atlas:`Data Lake
 </data-lake>`.
 

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -16,7 +16,8 @@ Release Notes
 *Released June 7, 2022*
 
 Fixes an issue where ``$out`` and ``$merge`` aggregation stages would
-not appear when connected to a :atlas:`Data Lake </data-lake>`.
+not appear in the pipeline builder when connected to a :atlas:`Data Lake
+</data-lake>`.
 
 `Full changelog available on GitHub
 <https://github.com/mongodb-js/compass/releases/tag/v1.32.2>`__.


### PR DESCRIPTION
Staged: https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-23128/release-notes/