### PR TITLE
DOCSP-22744 add QE to create collection/database procedures

### DIFF
--- a/source/includes/steps-create-collection.yaml
+++ b/source/includes/steps-create-collection.yaml
@@ -19,6 +19,17 @@ content: |
    </reference/collation/#collation-document>` on the collection,
    select the :guilabel:`Use Custom Collation` checkbox and select the
    desired collation settings.
+
+   If your deployment is connected using :guilabel:`In-Use Encryption`, you can 
+   use :v6.0:`Queryable Encryption </core/queryable-encryption/>` on the newly 
+   created collection. Select the :guilabel:`Queryable Encryption` checkbox
+   and indicate the following:
+
+   - :v6.0:`Encrypted Fields </core/queryable-encryption/fundamentals/encrypt-and-query/>`.
+
+   - (Optional) :v6.0:`KMS Provider </core/queryable-encryption/fundamentals/kms-providers/>`.
+
+   - (Optional) :v6.0:`Key Encryption Key </core/queryable-encryption/fundamentals/keys-key-vaults/>`. 
 ---
 title: Click :guilabel:`Create Collection` to create the collection.
 level: 4

--- a/source/includes/steps-create-database.yaml
+++ b/source/includes/steps-create-database.yaml
@@ -23,6 +23,18 @@ content: |
    </reference/collation/#collation-document>` on the newly created
    collection, select the :guilabel:`Use Custom Collation` checkbox
    and select the desired collation settings.
+
+   If your deployment is connected using :guilabel:`In-Use Encryption`, you can 
+   use :v6.0:`Queryable Encryption </core/queryable-encryption/>` on the newly 
+   created collection. Select the :guilabel:`Queryable Encryption` checkbox
+   and indicate the following:
+
+   - :v6.0:`Encrypted Fields </core/queryable-encryption/fundamentals/encrypt-and-query/>`.
+
+   - (Optional) :v6.0:`KMS Provider </core/queryable-encryption/fundamentals/kms-providers/>`.
+
+   - (Optional) :v6.0:`Key Encryption Key </core/queryable-encryption/fundamentals/keys-key-vaults/>`. 
+   
 ---
 title: Click :guilabel:`Create Database` to create the database and its first collection.
 level: 4


### PR DESCRIPTION
Added option to add Queryable Encryption to a collection in the Create a Database/Collection procedure.

JIRA: https://jira.mongodb.org/browse/DOCSP-22744

STAGING:(Create a Database) https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-22744/databases/#create-a-database

(Create a Collection): https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-22744/collections/#create-a-collection