### PR TITLE
Remove `Build index in the background` option

### DIFF
--- a/source/includes/steps-create-index.yaml
+++ b/source/includes/steps-create-index.yaml
@@ -58,13 +58,6 @@ content: |
        - Description
        - More Information
 
-     * - Build index in the background
-
-       - Ensure that the MongoDB deployment remains available during
-          the index build operation.
-
-       - :manual:`Background Construction </core/index-creation/index.html#background-construction>`
-
      * - Create unique index
 
        - Ensure that the indexed fields do not store duplicate values.


### PR DESCRIPTION
Compass dropped this option from the UI in `3.22.6`: https://jira.mongodb.org/browse/COMPASS-5952

I think it should be removed from the documentation as well, since it's misleading.