### PR TITLE
(DOCSP-25219): Export favorite connections with the CLI

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -10,14 +10,14 @@ intersphinx = [
 toc_landing_pages = [
     "/install", 
     "/connect", 
-    "/connect/favorite-connections"
+    "/connect/favorite-connections",
     "/instance", 
     "/query/filter", 
     "/query/queries",
     "/documents", 
     "/schema", 
     "/aggregation-pipeline-builder", 
-    "/collections",
+    "/collections"
 ]
 
 [constants]

--- a/snooty.toml
+++ b/snooty.toml
@@ -11,6 +11,7 @@ toc_landing_pages = [
     "/install", 
     "/connect", 
     "/connect/favorite-connections",
+    "/connect/favorite-connections/import-export-cli/"
     "/instance", 
     "/query/filter", 
     "/query/queries",

--- a/snooty.toml
+++ b/snooty.toml
@@ -7,8 +7,18 @@ intersphinx = [
     "https://www.mongodb.com/docs/mongodb-shell/objects.inv"
 ]
 
-toc_landing_pages = ["/install", "/connect", "/instance", "/query/filter", "/query/queries",
-                     "/documents", "/schema", "/aggregation-pipeline-builder", "collections"]
+toc_landing_pages = [
+    "/install", 
+    "/connect", 
+    "/connect/favorite-connections"
+    "/instance", 
+    "/query/filter", 
+    "/query/queries",
+    "/documents", 
+    "/schema", 
+    "/aggregation-pipeline-builder", 
+    "/collections",
+]
 
 [constants]
 download-page = "`downloads page <https://www.mongodb.com/download-center/compass?tck=docs_compass>`__"

--- a/snooty.toml
+++ b/snooty.toml
@@ -11,7 +11,7 @@ toc_landing_pages = [
     "/install", 
     "/connect", 
     "/connect/favorite-connections",
-    "/connect/favorite-connections/import-export-cli/"
+    "/connect/favorite-connections/import-export-cli/",
     "/instance", 
     "/query/filter", 
     "/query/queries",

--- a/source/connect/favorite-connections.txt
+++ b/source/connect/favorite-connections.txt
@@ -60,3 +60,8 @@ Considerations
   installed to successfully load saved connections. The Electron module
   `Keytar <https://github.com/atom/node-keytar>`__ uses GNOME Keyring
   to securely store the database credentials for your connections.
+
+.. toctree::
+   :titlesonly:
+
+   /connect/favorite-connections/import-export-cli

--- a/source/connect/favorite-connections/import-export-cli.txt
+++ b/source/connect/favorite-connections/import-export-cli.txt
@@ -1,0 +1,13 @@
+===================================================
+Import and Export Favorite Connections with the CLI
+===================================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+TODO: Write

--- a/source/connect/favorite-connections/import-export-cli.txt
+++ b/source/connect/favorite-connections/import-export-cli.txt
@@ -1,5 +1,7 @@
+.. _compass-export-import-cli-landing:
+
 ===================================================
-Import and Export Favorite Connections with the CLI
+Export and Import Favorite Connections with the CLI
 ===================================================
 
 .. default-domain:: mongodb
@@ -7,7 +9,35 @@ Import and Export Favorite Connections with the CLI
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 1
+   :depth: 2
    :class: singlecol
 
-TODO: Write
+You can use the |compass-short| :abbr:`CLI (Command-Line Interface)` to
+export and import favorite connections. This lets you share saved
+connections between workspaces and with colleagues to quickly connect to
+shared deployments.
+
+By default, |compass-short| does not hide sensitive connection
+information (such as usernames and passwords) from the exported
+connection file. You can optionally encrypt the exported file with a
+passphrase. When you do, users must specify the passphrase to view the
+file contents.
+
+Tasks
+-----
+
+To learn how to export and import connections, see these pages:
+
+- :ref:`compass-export-connections-cli`
+
+- :ref:`compass-import-connections-cli`
+
+- :ref:`compass-encrypt-connections-cli`
+
+.. toctree::
+   :titlesonly:
+
+   /connect/favorite-connections/import-export-cli/export
+   /connect/favorite-connections/import-export-cli/import
+   /connect/favorite-connections/import-export-cli/encrypt
+   

--- a/source/connect/favorite-connections/import-export-cli/encrypt.txt
+++ b/source/connect/favorite-connections/import-export-cli/encrypt.txt
@@ -1,0 +1,13 @@
+.. _compass-encrypt-connections-cli:
+
+============================
+Encrypt Exported Connections
+============================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol

--- a/source/connect/favorite-connections/import-export-cli/export.txt
+++ b/source/connect/favorite-connections/import-export-cli/export.txt
@@ -1,0 +1,102 @@
+.. _compass-export-connections-cli:
+
+========================================
+Export Favorite Connections with the CLI
+========================================
+
+You can use the |compass-short| :abbr:`CLI (Command-Line Interface)` to
+export favorite connections. This lets you share saved connections
+between workspaces and with colleagues to connect to shared deployments.
+
+About This Task
+---------------
+
+When you export favorite connections, |compass-short| exports the list
+of connections as a JSON file.
+
+By default, |compass-short| does not hide sensitive connection
+information (such as usernames and passwords) from the exported
+connection file. To learn how to protect sensitive information in
+exported connections, see :ref:`compass-encrypt-connections-cli`.
+
+Procedure
+---------
+
+To export **unencrypted** favorite connections using the |compass-short|
+:abbr:`CLI (Command-Line Interface)`, specify:
+
+- The path to the |compass| executable. The path to the executable
+  depends on your operating system.
+
+- The ``--export-connections`` flag with the value set to the
+  destination of the output file.
+
+Your operation should resemble the following prototype:
+
+.. code-block:: sh
+
+   <path-to-Compass-executable> --export-connections=<filename>
+
+Example
+-------
+
+This example exports favorite |compass-short| connections to a file with
+the path ``/tmp/compass-connections/favorites.json``:
+
+.. code-block:: sh
+
+   ./MongoDB\ Compass --export-connections=/tmp/compass-connections/favorites.json
+
+Results
+~~~~~~~
+
+After the export completes, the
+``/tmp/compass-connections/favorites.json`` file resembles the
+following:
+
+.. code-block:: json
+
+   {
+     "type": "Compass Connections",
+     "version": {
+       "$numberInt": "1"
+     },
+     "connections": [
+       {
+         "id": "5a92e195-3ef5-49ae-aff6-720af362770d",
+         "connectionOptions": {
+           "connectionString": "<connection string>"
+         },
+         "favorite": {
+           "name": "QA Cluster",
+           "color": "color7"
+         },
+         "lastUsed": {
+           "$date": {
+             "$numberLong": "1663785601002"
+           }
+         }
+       },
+       {
+         "id": "655f3e6e-b13b-4813-8578-50d896bd9240",
+         "connectionOptions": {
+           "connectionString": "mongodb://localhost:27017/"
+         },
+         "favorite": {
+           "name": "Local Host",
+           "color": "color7"
+         },
+         "lastUsed": {
+           "$date": {
+             "$numberLong": "1663790327679"
+           }
+         }
+       }
+     ]
+   }
+
+Next Steps
+----------
+
+To learn how to import exported connections, see
+:ref:`compass-import-connections-cli`.

--- a/source/connect/favorite-connections/import-export-cli/export.txt
+++ b/source/connect/favorite-connections/import-export-cli/export.txt
@@ -4,6 +4,14 @@
 Export Favorite Connections with the CLI
 ========================================
 
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
 You can use the |compass-short| :abbr:`CLI (Command-Line Interface)` to
 export favorite connections. This lets you share saved connections
 between workspaces and with colleagues to connect to shared deployments.

--- a/source/connect/favorite-connections/import-export-cli/import.txt
+++ b/source/connect/favorite-connections/import-export-cli/import.txt
@@ -1,0 +1,5 @@
+.. _compass-import-connections-cli:
+
+========================================
+Import Favorite Connections with the CLI
+========================================


### PR DESCRIPTION
### DESCRIPTION

This PR adds these pages:

- Landing page for CLI import / export
- Page for exporting a favorite connection (unencrypted)

Importing and encrypting are coming in future PRs.

### JIRA

[DOCSP-25554](https://jira.mongodb.org/browse/DOCSP-25554 ) (part of [DOCSP-25219](https://jira.mongodb.org/browse/DOCSP-25219))

### STAGING

https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-25554/connect/favorite-connections/import-export-cli/

