### PR TITLE
(DOCSP-19876): Full-text search stages do not work on time-series collections

### DIFF
--- a/source/aggregation-pipeline-builder.txt
+++ b/source/aggregation-pipeline-builder.txt
@@ -55,7 +55,7 @@ Limitations
 -----------
 
 - The :pipeline:`$out` stage is not available if you are connected to a
-  `Data Lake <https://www.mongodb.com/atlas/data-lake>`__.
+  :atlas:`Data Lake </data-lake>`.
 
 - You cannot run the :atlas:`$search </atlas-search/query-syntax>` stage
   on a :ref:`time series collection <manual-timeseries-landing>`.

--- a/source/aggregation-pipeline-builder.txt
+++ b/source/aggregation-pipeline-builder.txt
@@ -55,8 +55,11 @@ You can:
 Limitations
 -----------
 
-The :pipeline:`$out` stage is not available if you are connected to a
-`Data Lake <https://www.mongodb.com/atlas/data-lake>`__.
+- The :pipeline:`$out` stage is not available if you are connected to a
+  `Data Lake <https://www.mongodb.com/atlas/data-lake>`__.
+
+- You cannot run the :pipeline:`$search` stage on a :ref:`time series
+  collection <manual-timeseries-landing>`.
 
 .. _create-agg-pipeline:
 

--- a/source/aggregation-pipeline-builder.txt
+++ b/source/aggregation-pipeline-builder.txt
@@ -14,12 +14,11 @@ Aggregation Pipeline Builder
 
 *New in version 1.14.0*
 
-The Aggregation Pipeline Builder in |compass| provides the ability to
-create :manual:`aggregation pipelines </core/aggregation-pipeline/>` to
-process data. In aggregation pipelines, documents in a collection
-or view pass through stages where |compass| processes them into a
-set of aggregated results. You can change the stages and results to
-suit your needs.
+The Aggregation Pipeline Builder in |compass| lets you create
+:manual:`aggregation pipelines </core/aggregation-pipeline/>` to process
+data. In aggregation pipelines, documents in a collection or view pass
+through stages where |compass| processes them into a set of aggregated
+results. You can change the stages and results to suit your needs.
 
 To start building an aggregation pipeline for a :doc:`collection or view
 </collections>`, choose the collection and click the
@@ -58,8 +57,8 @@ Limitations
 - The :pipeline:`$out` stage is not available if you are connected to a
   `Data Lake <https://www.mongodb.com/atlas/data-lake>`__.
 
-- You cannot run the :pipeline:`$search` stage on a :ref:`time series
-  collection <manual-timeseries-landing>`.
+- You cannot run the :atlas:`$search </atlas-search/query-syntax>` stage
+  on a :ref:`time series collection <manual-timeseries-landing>`.
 
 .. _create-agg-pipeline:
 


### PR DESCRIPTION
## JIRA

https://jira.mongodb.org/browse/DOCSP-19876

## STAGED

https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-19876/aggregation-pipeline-builder/#limitations

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6392231fdc742b91f2e7b3b0