### PR TITLE
DOCSP-27090 Add Atlas only stage note

### DIFF
--- a/source/aggregation-pipeline-builder.txt
+++ b/source/aggregation-pipeline-builder.txt
@@ -40,7 +40,7 @@ collection.
    :atlas:`$searchMeta </reference/atlas-search/query-syntax/#-searchmeta>`
    are available in the Aggregation Pipeline Builder. Use these stages 
    to perform 
-   :atlas:`full-text search</atlas/atlas-search/atlas-search-overview/>` 
+   :atlas:`full-text search</reference/atlas/atlas-search/atlas-search-overview/>` 
    on Atlas collections.
 
 Tasks

--- a/source/aggregation-pipeline-builder.txt
+++ b/source/aggregation-pipeline-builder.txt
@@ -31,6 +31,13 @@ aggregation pipeline. The :guilabel:`Preview of Documents in the
 Collection` section shows 20 documents randomly sampled from the chosen
 collection.
 
+.. note::
+
+   When you connect Compass to MongoDB instances hosted on 
+   `Atlas <https://www.mongodb.com/cloud/atlas?tck=docs_compass>`_
+   Atlas only stages ``$search`` and ``$searchMeta`` are 
+   available in the Pipeline editor. 
+
 Tasks
 -----
 

--- a/source/aggregation-pipeline-builder.txt
+++ b/source/aggregation-pipeline-builder.txt
@@ -34,7 +34,7 @@ collection.
 .. note:: 
 
    When you connect Compass to MongoDB instances hosted on 
-   `Atlas <https://www.mongodb.com/cloud/atlas?tck=docs_compass>`_
+   `Atlas <https://www.mongodb.com/cloud/atlas?tck=docs_compass>`_,
    additional Atlas only stages ``$search`` and ``$searchMeta`` are 
    available in the Aggregation Pipeline Builder. 
 

--- a/source/aggregation-pipeline-builder.txt
+++ b/source/aggregation-pipeline-builder.txt
@@ -35,7 +35,7 @@ collection.
 
    When you connect Compass to MongoDB instances hosted on 
    `Atlas <https://www.mongodb.com/cloud/atlas?tck=docs_compass>`_
-   Atlas only stages ``$search`` and ``$searchMeta`` are 
+   additional Atlas only stages ``$search`` and ``$searchMeta`` are 
    available in the Pipeline editor. 
 
 Tasks

--- a/source/aggregation-pipeline-builder.txt
+++ b/source/aggregation-pipeline-builder.txt
@@ -40,7 +40,7 @@ collection.
    :atlas:`$searchMeta </reference/atlas-search/query-syntax/#-searchmeta>`
    are available in the Aggregation Pipeline Builder. Use these stages 
    to perform 
-   :atlas:`full-text search</reference/atlas-search/atlas-search-overview>` 
+   :atlas:`full-text search</atlas-search/atlas-search-overview>` 
    on Atlas collections.
 
 Tasks

--- a/source/aggregation-pipeline-builder.txt
+++ b/source/aggregation-pipeline-builder.txt
@@ -37,7 +37,7 @@ collection.
    `Atlas <https://www.mongodb.com/cloud/atlas?tck=docs_compass>`_,
    additional Atlas-only stages 
    :atlas:`$search </reference/atlas-search/query-syntax/#-search>` and
-   :atlas:`$searchMeta /reference/atlas-search/query-syntax/#-searchmeta>`
+   :atlas:`$searchMeta </reference/atlas-search/query-syntax/#-searchmeta>`
     are available in the Aggregation Pipeline Builder.
 
 Tasks

--- a/source/aggregation-pipeline-builder.txt
+++ b/source/aggregation-pipeline-builder.txt
@@ -31,12 +31,12 @@ aggregation pipeline. The :guilabel:`Preview of Documents in the
 Collection` section shows 20 documents randomly sampled from the chosen
 collection.
 
-.. note::
+.. note:: 
 
    When you connect Compass to MongoDB instances hosted on 
    `Atlas <https://www.mongodb.com/cloud/atlas?tck=docs_compass>`_
    additional Atlas only stages ``$search`` and ``$searchMeta`` are 
-   available in the Pipeline editor. 
+   available in the Aggregation Pipeline Builder. 
 
 Tasks
 -----

--- a/source/aggregation-pipeline-builder.txt
+++ b/source/aggregation-pipeline-builder.txt
@@ -40,7 +40,7 @@ collection.
    :atlas:`$searchMeta </reference/atlas-search/query-syntax/#-searchmeta>`
    are available in the Aggregation Pipeline Builder. Use these stages 
    to perform 
-   :atlas:`full-text search</reference/atlas-search/atlas-search-overview/>` 
+   :atlas:`full-text search</reference/atlas-search/atlas-search-overview>` 
    on Atlas collections.
 
 Tasks

--- a/source/aggregation-pipeline-builder.txt
+++ b/source/aggregation-pipeline-builder.txt
@@ -38,7 +38,10 @@ collection.
    additional Atlas-only stages 
    :atlas:`$search </reference/atlas-search/query-syntax/#-search>` and
    :atlas:`$searchMeta </reference/atlas-search/query-syntax/#-searchmeta>`
-   are available in the Aggregation Pipeline Builder.
+   are available in the Aggregation Pipeline Builder. Use these stages 
+   to perform 
+   :atlas:`full-text search</atlas/atlas-search/atlas-search-overview/>` 
+   on Atlas collections.
 
 Tasks
 -----

--- a/source/aggregation-pipeline-builder.txt
+++ b/source/aggregation-pipeline-builder.txt
@@ -31,12 +31,14 @@ aggregation pipeline. The :guilabel:`Preview of Documents in the
 Collection` section shows 20 documents randomly sampled from the chosen
 collection.
 
-.. note:: 
+.. note:: Atlas Search Stages
 
-   When you connect Compass to MongoDB instances hosted on 
+   When you connect |compass-short| to a MongoDB deployment hosted on 
    `Atlas <https://www.mongodb.com/cloud/atlas?tck=docs_compass>`_,
-   additional Atlas only stages ``$search`` and ``$searchMeta`` are 
-   available in the Aggregation Pipeline Builder. 
+   additional Atlas-only stages 
+   :atlas:`$search </reference/atlas-search/query-syntax/#-search>` and
+   :atlas:`$searchMeta /reference/atlas-search/query-syntax/#-searchmeta>`
+    are available in the Aggregation Pipeline Builder.
 
 Tasks
 -----

--- a/source/aggregation-pipeline-builder.txt
+++ b/source/aggregation-pipeline-builder.txt
@@ -40,7 +40,7 @@ collection.
    :atlas:`$searchMeta </reference/atlas-search/query-syntax/#-searchmeta>`
    are available in the Aggregation Pipeline Builder. Use these stages 
    to perform 
-   :atlas:`full-text search</reference/atlas/atlas-search/atlas-search-overview/>` 
+   :atlas:`full-text search</reference/atlas-search/atlas-search-overview/>` 
    on Atlas collections.
 
 Tasks

--- a/source/aggregation-pipeline-builder.txt
+++ b/source/aggregation-pipeline-builder.txt
@@ -38,7 +38,7 @@ collection.
    additional Atlas-only stages 
    :atlas:`$search </reference/atlas-search/query-syntax/#-search>` and
    :atlas:`$searchMeta </reference/atlas-search/query-syntax/#-searchmeta>`
-    are available in the Aggregation Pipeline Builder.
+   are available in the Aggregation Pipeline Builder.
 
 Tasks
 -----

--- a/source/command-line-options.txt
+++ b/source/command-line-options.txt
@@ -103,7 +103,7 @@ overrides the value in the :guilabel:`Settings` panel.
 .. option:: --protectConnectionStrings
 
    Hide credentials in connection strings. Passwords in connection 
-   strings are displayed as `*****`. 
+   strings are displayed as ``*****``. 
 
 .. option:: --theme
 


### PR DESCRIPTION
## DESCRIPTION

Adding callout that Additional stages `$search` and `$serchMeta` are available when a user connects compass to Atlas. 

## STAGING

https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-27090/aggregation-pipeline-builder/


## JIRA
https://jira.mongodb.org/browse/DOCSP-27090

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=63a475c8dc742b91f284ed12


## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)