### PR TITLE
DOCSP-26528 Adding username and password parameters to CLI page

### DIFF
--- a/source/command-line-options.txt
+++ b/source/command-line-options.txt
@@ -103,7 +103,7 @@ overrides the value in the :guilabel:`Settings` panel.
 .. option:: --protectConnectionStrings
 
    Hide credentials in connection strings. Passwords in connection 
-   strings are displayed as `*****`. 
+   strings are displayed as ``*****``. 
 
 .. option:: --theme
 

--- a/source/connect/connect-from-the-command-line.txt
+++ b/source/connect/connect-from-the-command-line.txt
@@ -68,7 +68,8 @@ connection string:
 .. code-block:: shell
    :copyable: false
 
-   mongodb-compass mongodb+srv://cluster0.cpxklfq.mongodb.net/library --username user1 --password password1
+   mongodb-compass mongodb+srv://cluster0.cpxklfq.mongodb.net/library 
+   --username user1 --password password1
 
 .. _compass-connect-file-based:
 

--- a/source/connect/connect-from-the-command-line.txt
+++ b/source/connect/connect-from-the-command-line.txt
@@ -65,7 +65,7 @@ connection details to connect to your MongoDB installation:
 .. code-block:: shell
    :copyable: true
  
-   mongodb-compass mongodb+srv://cluster0.cpxklfq.mongodb.net/library
+   mongodb-compass mongodb+srv://xxxxxxx.yyyyyy.mongodb.net/library
 
 Username and Password Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -77,7 +77,7 @@ connection string:
 .. code-block:: shell
    :copyable: true
 
-   mongodb-compass mongodb+srv://cluster0.cpxklfq.mongodb.net/library 
+   mongodb-compass mongodb+srv://xxxxxxx.yyyyyy.mongodb.net/library 
    --username user1 --password password1
 
 .. _compass-connect-file-based:

--- a/source/connect/connect-from-the-command-line.txt
+++ b/source/connect/connect-from-the-command-line.txt
@@ -43,8 +43,14 @@ format is:
 
 .. code-block:: shell
    :copyable: false
- 
-    <path/to/compass/executable> <connection string>
+
+    <path/to/compass/executable> <connection string> --username <username> --password <password>
+
+
+.. note:: 
+
+   If the username and password arguments are not provided, Compass will
+   attempt to use the credentials in the URL.
 
 This example is like the basic connection string for a `MongoDB
 University <https://learn.mongodb.com/>`__ training cluster. Modify the
@@ -54,7 +60,15 @@ connection details to connect to your MongoDB installation:
    :copyable: false
  
    mongodb-compass mongodb+srv://cluster0.cpxklfq.mongodb.net/library
- 
+
+This example uses the ``username`` and ``password`` parameters to 
+authenticate Compass to the MongoDB deployment provided in the 
+connection string:
+
+.. code-block:: shell
+   :copyable: false
+
+   mongodb-compass mongodb+srv://cluster0.cpxklfq.mongodb.net/library --username user1 --password password1
 
 .. _compass-connect-file-based:
 

--- a/source/connect/connect-from-the-command-line.txt
+++ b/source/connect/connect-from-the-command-line.txt
@@ -38,7 +38,8 @@ Command Line Connection Specification
 -------------------------------------
 
 The command line invocation for |compass-short| has two components, the 
-path to the |compass-short| executable and a connection string. The
+path to the |compass-short| executable and a connection string, you can
+optionally pass in the username and password parameters. The
 format is:
 
 .. code-block:: shell

--- a/source/connect/connect-from-the-command-line.txt
+++ b/source/connect/connect-from-the-command-line.txt
@@ -39,20 +39,20 @@ Command Line Connection Specification
 
 The command line invocation for |compass-short| has two components, the 
 path to the |compass-short| executable and a connection string, you can
-optionally pass in the username and password parameters. The
-format is:
+optionally provide the username and password  on the command line or
+the configuration file. The format is:
 
 .. code-block:: shell
    :copyable: false
 
-    <path/to/compass/executable> <connection string> 
+    <path/to/compass/executable> 
+    <connection string> 
     --username <username> --password <password>
-
 
 .. note:: 
 
-   If the username and password arguments are not provided, Compass will
-   attempt to use the credentials in the connection string.
+   If the username and password arguments are not provided, Compass uses
+   the credentials in the connection string.
 
 
 Basic Connection String

--- a/source/connect/connect-from-the-command-line.txt
+++ b/source/connect/connect-from-the-command-line.txt
@@ -53,12 +53,12 @@ format is:
    If the username and password arguments are not provided, Compass will
    attempt to use the credentials in the connection string.
 
-This example is like the basic connection string for a `MongoDB
+The following example uses a basic connection string for a `MongoDB
 University <https://learn.mongodb.com/>`__ training cluster. Modify the
 connection details to connect to your MongoDB installation:  
 
 .. code-block:: shell
-   :copyable: false
+   :copyable: true
  
    mongodb-compass mongodb+srv://cluster0.cpxklfq.mongodb.net/library
 
@@ -67,7 +67,7 @@ authenticate Compass to the MongoDB deployment provided in the
 connection string:
 
 .. code-block:: shell
-   :copyable: false
+   :copyable: true
 
    mongodb-compass mongodb+srv://cluster0.cpxklfq.mongodb.net/library 
    --username user1 --password password1

--- a/source/connect/connect-from-the-command-line.txt
+++ b/source/connect/connect-from-the-command-line.txt
@@ -54,6 +54,10 @@ format is:
    If the username and password arguments are not provided, Compass will
    attempt to use the credentials in the connection string.
 
+
+Basic Connection String
+~~~~~~~~~~~~~~~~~~~~~~~
+
 The following example uses a basic connection string for a `MongoDB
 University <https://learn.mongodb.com/>`__ training cluster. Modify the
 connection details to connect to your MongoDB installation:  
@@ -62,6 +66,9 @@ connection details to connect to your MongoDB installation:
    :copyable: true
  
    mongodb-compass mongodb+srv://cluster0.cpxklfq.mongodb.net/library
+
+Username and Password Parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This example uses the ``username`` and ``password`` parameters to 
 authenticate Compass to the MongoDB deployment provided in the 

--- a/source/connect/connect-from-the-command-line.txt
+++ b/source/connect/connect-from-the-command-line.txt
@@ -38,8 +38,8 @@ Command Line Connection Specification
 -------------------------------------
 
 The command line invocation for |compass-short| has two components, the 
-path to the |compass-short| executable and a connection string, you can
-optionally provide the username and password  on the command line or
+path to the |compass-short| executable and a connection string. You can
+optionally provide the username and password on the command line or
 the configuration file. The format is:
 
 .. code-block:: shell

--- a/source/connect/connect-from-the-command-line.txt
+++ b/source/connect/connect-from-the-command-line.txt
@@ -65,7 +65,7 @@ connection details to connect to your MongoDB installation:
 .. code-block:: shell
    :copyable: true
  
-   mongodb-compass mongodb+srv://xxxxxxx.yyyyyy.mongodb.net/library
+   mongodb-compass mongodb+srv://cluster0.xxxxxx.mongodb.net/library
 
 Username and Password Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -77,7 +77,7 @@ connection string:
 .. code-block:: shell
    :copyable: true
 
-   mongodb-compass mongodb+srv://xxxxxxx.yyyyyy.mongodb.net/library 
+   mongodb-compass mongodb+srv://cluster0.xxxxxx.mongodb.net/library 
    --username user1 --password password1
 
 .. _compass-connect-file-based:

--- a/source/connect/connect-from-the-command-line.txt
+++ b/source/connect/connect-from-the-command-line.txt
@@ -44,13 +44,14 @@ format is:
 .. code-block:: shell
    :copyable: false
 
-    <path/to/compass/executable> <connection string> --username <username> --password <password>
+    <path/to/compass/executable> <connection string> 
+    --username <username> --password <password>
 
 
 .. note:: 
 
    If the username and password arguments are not provided, Compass will
-   attempt to use the credentials in the URL.
+   attempt to use the credentials in the connection string.
 
 This example is like the basic connection string for a `MongoDB
 University <https://learn.mongodb.com/>`__ training cluster. Modify the


### PR DESCRIPTION
## Description

Adding command line arguments username and password to the Compass CLI page + adding an example

## Staging

https://docs-mongodborg-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-26528/connect/connect-from-the-command-line/#command-line-connection-specification

## Build
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=63af1c0edc742b91f27e8c66

## Jira
https://jira.mongodb.org/browse/DOCSP-26528
