### PR TITLE
DOCSP-27268 Compass 1.35 release notes

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -25,7 +25,7 @@ toc_landing_pages = [
 
 [constants]
 download-page = "`downloads page <https://www.mongodb.com/download-center/compass?tck=docs_compass>`__"
-current-version = "1.34.2"
+current-version = "1.35.0"
 
 [[banners]]
 targets = [

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -10,6 +10,78 @@ Release Notes
    :depth: 1
    :class: twocols
 
+
+|compass| 1.35.0
+----------------
+
+*Released January 11, 2023*
+
+New Features
+
+- Update export modal to LeafyGreen components (:issue:`COMPASS-6220`)
+- Replace types dropdown with LG select
+- Use leafygreen combobox to select stages
+- Replace export-to-language with leafygreen components (:issue:`COMPASS-6219`)
+- Add connection import/export UI
+- Convert compass query history to new components (:issue:`COMPASS-6221`)
+- Use the same date hook in query history as in saved aggregations (:issue:`COMPASS-6221`)
+- Add forceConnectionOptions option (:issue:`COMPASS-6068`)
+- Implement readOnly option (:issue:`COMPASS-6064`)
+- Update import modal to LeafyGreen components (:issue:`COMPASS-6220`)
+- Add --username and --password for auto-connect (:issue:`COMPASS-6216`)
+- Expose protectConnectionStrings in settings UI (:issue:`COMPASS-6262`)
+- Kerberos password field setting (:issue:`COMPASS-5950`)
+- Add maxTimeMS as setting (:issue:`COMPASS-6063`)
+- Update compass validation components to leafygreen (:issue:`COMPASS-6237`)
+- Update explain plan components (:issue:`COMPASS-6236`)
+- Implement enableDevTools option (:issue:`COMPASS-6061`), (:issue:`COMPASS-5615`)
+- Use rebranded components in the document table view
+- Add tracking event when stage value changes (:issue:`COMPASS-6310`)
+- Update Compass aggregations modals (:issue:`COMPASS-6286`)
+- Add LG darkTheme support for table view
+- Remove trackErrors setting (:issue:`COMPASS-5708`)
+- Move all autoupdates logic to compass main process, allow to dismiss updates (:issue:`COMPASS-6057`) (:issue:`COMPASS-6303`)
+- Convert more insert dialog code to compass components & leafygreen (:issue:`COMPASS-6285`)
+- Register Compass as a protocol handler for ``mongodb://`` (:issue:`COMPASS-6085`)
+- Add ``--show-example-config`` flag (:issue:`COMPASS-6084`)
+- Cancellable aggregate and schema analysis (:issue:`COMPASS-5668`)
+- Cancellable find and explain (:issue:`COMPASS-5668`)
+- Implement new input docs card design (:issue:`COMPASS-6234`)
+- Update scrollbar styles (:issue:`COMPASS-5597`)
+- Cancellable counts (:issue:`COMPASS-5668`)
+- Update aggregations stage components (:issue:`COMPASS-6234`)
+- Enable pipeline as text feature (:issue:`COMPASS-6299`)
+- Index tab UI improvements (:issue:`COMPASS-6323`), (:issue:`COMPASS-6329`)
+- Add refresh document count in aggregation results (:issue:`COMPASS-6156`)
+- Confirm when deleting pipeline (:issue:`COMPASS-4137`)
+
+Bug Fixes
+
+- Improve table view interactions
+- Do not save auto-connection in recents (:issue:`COMPASS-6290`)
+- Check for root level when deciding if _id key is editable (:issue:`COMPASS-6160`)
+- Fix the saved pipelines popover's scrolling (:issue:`COMPASS-6277`)
+- Disable deprecation warnings in production (:issue:`COMPASS-6322`)
+- Ignore non-digits in number input (:issue:`COMPASS-6326`)
+- Speed up export (:issue:`COMPASS-6332`)
+- Increase compass schema value bubble contrast (:issue:`COMPASS-6230`)
+- Fix macOS protocol handler connection string passing
+- Fix typo on Indexes screen
+- Avoid race condition when installing listeners
+- Hide delete for db/coll cards in readonly mode (:issue:`COMPASS-6292`)
+- Freeze settings modal height and adjust categories (:issue:`COMPASS-6325`)
+- Fix nested field autocomplete (:issue:`COMPASS-6335`)
+- Reset contains error check on document json view edit cancel (:issue:`COMPASS-6059`)
+- Pass the preference as a prop when nesting Field (:issue:`COMPASS-6363`)
+- Hide add stage in toolbar (:issue:`COMPASS-6373`)
+- Make $out options more clear in agg pipeline builder (:issue:`COMPASS-6304`)
+- Speed up document json view (:issue:`COMPASS-6365`)
+- Export to Language (Java) has incorrect class name (:issue:`COMPASS-6159`)
+- Enable next page button when count is unknown (:issue:`COMPASS-6340`)
+- Initialize before identify and use get-os-info from npm
+- Output stage destination name (:issue:`COMPASS-6407`)
+- Set width of compass shell to avoid overflow (:issue:`COMPASS-6411`)
+
 |compass| 1.34.2
 ----------------
 

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -16,7 +16,7 @@ Release Notes
 
 *Released January 11, 2023*
 
-New Features
+New Features:
 
 - Update export modal to LeafyGreen components (:issue:`COMPASS-6220`)
 - Replace types dropdown with LG select
@@ -55,7 +55,7 @@ New Features
 - Add refresh document count in aggregation results (:issue:`COMPASS-6156`)
 - Confirm when deleting pipeline (:issue:`COMPASS-4137`)
 
-Bug Fixes
+Bug Fixes:
 
 - Improve table view interactions
 - Do not save auto-connection in recents (:issue:`COMPASS-6290`)


### PR DESCRIPTION
## DESCRIPTION

Copy and paste from the 1.35 [whats changed](https://github.com/mongodb-js/compass/releases) section. Removed a few items that are not relevant for the release

## STAGING

https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-27268/release-notes/


## BUILD

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=63beeecddc742b91f29bc0a3


## JIRA

https://jira.mongodb.org/browse/DOCSP-27268

