### PR TITLE
DOCSP-26519 Enable Shell UI Settings

### DIFF
--- a/source/embedded-shell.txt
+++ b/source/embedded-shell.txt
@@ -84,8 +84,7 @@ To disable the embedded MongoDB shell:
       |compass-short| opens a dialog box where configure your |compass| 
       settings.
 
-   .. step:: Toggle :guilabel:`Enable MongoDB Shell` to disable the embedded 
-      shell on |compass-short|.
+   .. step:: Toggle :guilabel:`Enable MongoDB Shell`.
 
       If you select :guilabel:`Set Read-Only Mode`, |compass-short| 
       automatically disables the :guilabel:`Enable MongoDB Shell` setting.

--- a/source/embedded-shell.txt
+++ b/source/embedded-shell.txt
@@ -85,12 +85,12 @@ To disable the embedded MongoDB shell:
       settings.
 
    .. step:: Toggle :guilabel:`Enable MongoDB Shell` to disable
-      :binary:`mongosh` on |compass-short|
+      :binary:`mongosh` on |compass-short|.
 
       If you select :guilabel:`Set Read-Only Mode`, |compass-short| 
       automatically disables the :guilabel:`Enable MongoDB Shell` setting.
 
-   .. step:: Click :guilable:`Save`. 
+   .. step:: Click :guilabel:`Save`. 
 
 Learn More
 ~~~~~~~~~~

--- a/source/embedded-shell.txt
+++ b/source/embedded-shell.txt
@@ -66,6 +66,32 @@ an :ref:`aggregation pipeline <aggregation-pipeline>`:
         { $match: { "last_name": "Smith" } } // press Shift + Enter
       ] )                                    // Press Enter
 
+Disable the Embedded MongoDB Shell
+----------------------------------
+
+You can disable the embedded MongoDB shell in |compass-short| to restrict 
+users from running unauthorized commands on :binary:`mongosh`. 
+
+To disable the embedded MongoDB shell: 
+
+.. procedure::
+   :style: normal
+
+   .. step:: In the |compass-short| top menu bar, click :guilabel:`Help`.
+
+   .. step:: In the :guilabel:`Help` menu, click :guilabel:`Settings`.
+
+      |compass-short| opens a dialog box where configure your |compass| 
+      settings.
+
+   .. step:: Toggle :guilabel:`Enable MongoDB Shell` to disable
+      :binary:`mongosh` on |compass-short|
+
+      If you select :guilabel:`Set Read-Only Mode`, |compass-short| 
+      automatically disables the :guilabel:`Enable MongoDB Shell` setting.
+
+   .. step:: Click :guilable:`Save`. 
+
 Learn More
 ~~~~~~~~~~
 

--- a/source/embedded-shell.txt
+++ b/source/embedded-shell.txt
@@ -80,7 +80,7 @@ To disable the embedded MongoDB shell:
    .. step:: In the |compass-short| top menu bar, click :guilabel:`Help`.
 
    .. step:: In the :guilabel:`Help` menu, click :guilabel:`Settings`.
-
+      
       |compass-short| opens a dialog box where configure your |compass| 
       settings.
 

--- a/source/embedded-shell.txt
+++ b/source/embedded-shell.txt
@@ -69,8 +69,8 @@ an :ref:`aggregation pipeline <aggregation-pipeline>`:
 Disable the Embedded MongoDB Shell
 ----------------------------------
 
-You can disable the embedded MongoDB shell in |compass-short| to restrict 
-users from running unauthorized commands on :binary:`mongosh`. 
+You can disable the embedded MongoDB shell in |compass-short| to avoid running 
+unauthorized commands on :binary:`mongosh`. 
 
 To disable the embedded MongoDB shell: 
 
@@ -81,13 +81,13 @@ To disable the embedded MongoDB shell:
 
    .. step:: In the :guilabel:`Help` menu, click :guilabel:`Settings`.
       
-      |compass-short| opens a dialog box where configure your |compass| 
+      |compass-short| opens a dialog box where you configure your |compass| 
       settings.
 
    .. step:: Toggle :guilabel:`Enable MongoDB Shell`.
 
       If you select :guilabel:`Set Read-Only Mode`, |compass-short| 
-      automatically disables the :guilabel:`Enable MongoDB Shell` setting.
+      automatically unchecks the :guilabel:`Enable MongoDB Shell` setting.
 
    .. step:: Click :guilabel:`Save`. 
 

--- a/source/embedded-shell.txt
+++ b/source/embedded-shell.txt
@@ -84,8 +84,8 @@ To disable the embedded MongoDB shell:
       |compass-short| opens a dialog box where configure your |compass| 
       settings.
 
-   .. step:: Toggle :guilabel:`Enable MongoDB Shell` to disable
-      :binary:`mongosh` on |compass-short|.
+   .. step:: Toggle :guilabel:`Enable MongoDB Shell` to disable the embedded 
+      shell on |compass-short|.
 
       If you select :guilabel:`Set Read-Only Mode`, |compass-short| 
       automatically disables the :guilabel:`Enable MongoDB Shell` setting.


### PR DESCRIPTION
## DESCRIPTION
Add information about disabling/enabling the embedded shell on the settings interface. Opted to focus on disabling since there are other relevant circumstances to note alongside it (i.e. limitations of set read-only mode)

## JIRA 
https://jira.mongodb.org/browse/DOCSP-26519

## STAGING 
https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-26519-enable-shell-ui-settings/embedded-shell/#disable-the-embedded-mongodb-shell

## BUILD 
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=63ecf46fdcefe97797aa76b3