### PR TITLE
DOCSP-27956 Add bucketMaxSpanSeconds and bucketRoundingSeconds

### DIFF
--- a/source/collections/time-series-collection.txt
+++ b/source/collections/time-series-collection.txt
@@ -67,8 +67,7 @@ Procedure
          
          * - ``bucketMaxSpanSeconds``
            -  The ``bucketMaxSpanSeconds`` field specifies the maximum time span 
-              between measurements in a :manual:`bucket 
-              </core/timeseries/timeseries-granularity/#flexible-bucketing>`. 
+              between measurements in a bucket. 
 
               The value of ``bucketMaxSpanSeconds`` must be the same as 
               ``bucketRoundingSeconds``. If you set the ``bucketMaxSpanSeconds``, 
@@ -76,15 +75,15 @@ Procedure
 
          * - ``bucketRoundingSeconds``
            -  The ``bucketRoundingSeconds`` field specifies the time interval 
-              that determines the starting timestamp for a new :manual:`bucket 
-              </core/timeseries/timeseries-granularity/#flexible-bucketing>`. 
+              that determines the starting timestamp for a new bucket. 
 
               The value of ``bucketRoundingSeconds`` must be the same as 
               ``bucketMaxSpanSeconds``. If you set the ``bucketRoundingSeconds``, 
               parameter, you can't set the ``granularity`` parameter.
 
       For more information on time series fields, see 
-      :manual:`</core/timeseries/timeseries-procedures/#timeseries-object-fields>`.
+      :manual:`Time Series Object Fields 
+      </core/timeseries/timeseries-procedures/#timeseries-object-fields>`.
 
    .. step:: Click :guilabel:`Create Collection` to create the collection.
 

--- a/source/collections/time-series-collection.txt
+++ b/source/collections/time-series-collection.txt
@@ -52,18 +52,39 @@ Procedure
              is used to label a unique series of documents. 
 
          * - ``granularity``
-           - The ``granularity`` field allows specifying a coarser granularity so 
-             measurements over a longer time span can be more efficiently stored 
-             and queried.
+           - The ``granularity`` field allows you to specify a coarser 
+             granularity so measurements over a longer time span can be more 
+             efficiently stored and queried.
 
              The default value is set to ``seconds``.
+
+             If you set the ``granularity`` parameter, you can't set the 
+             ``bucketMaxSpanSeconds`` and ``bucketRoundingSeconds`` parameters.
 
          * - ``expireAfterSeconds``
            -  The ``expireAfterSeconds`` field enables automatic deletion of 
               documents older than the specified number of seconds.  
+         
+         * - ``bucketMaxSpanSeconds``
+           -  The ``bucketMaxSpanSeconds`` field specifies the maximum time span 
+              between measurements in a :manual:`bucket 
+              </core/timeseries/timeseries-granularity/#flexible-bucketing>`. 
+
+              The value of ``bucketMaxSpanSeconds`` must be the same as 
+              ``bucketRoundingSeconds``. If you set the ``bucketMaxSpanSeconds``, 
+              parameter, you can't set the ``granularity`` parameter.
+
+         * - ``bucketRoundingSeconds``
+           -  The ``bucketRoundingSeconds`` field specifies the time interval 
+              that determines the starting timestamp for a new :manual:`bucket 
+              </core/timeseries/timeseries-granularity/#flexible-bucketing>`. 
+
+              The value of ``bucketRoundingSeconds`` must be the same as 
+              ``bucketMaxSpanSeconds``. If you set the ``bucketRoundingSeconds``, 
+              parameter, you can't set the ``granularity`` parameter.
 
       For more information on time series fields, see 
-      :manual:`Time Series Collections </core/timeseries-collections/>`.
+      :manual:`</core/timeseries/timeseries-procedures/#timeseries-object-fields>`.
 
    .. step:: Click :guilabel:`Create Collection` to create the collection.
 

--- a/source/collections/time-series-collection.txt
+++ b/source/collections/time-series-collection.txt
@@ -52,10 +52,10 @@ Procedure
              is used to label a unique series of documents. 
 
          * - ``granularity``
-           - Lets you specify a coarser granularity so measurements over a 
+           - Specifies a coarser granularity so measurements over a 
              longer time span can be more efficiently stored and queried.
 
-             The default value is set to ``"seconds"``.
+             The default value is ``"seconds"``.
 
              If you set the ``granularity`` parameter, you can't set the 
              ``bucketMaxSpanSeconds`` and ``bucketRoundingSeconds`` parameters.

--- a/source/collections/time-series-collection.txt
+++ b/source/collections/time-series-collection.txt
@@ -41,17 +41,20 @@ Procedure
 
       .. list-table::
          :header-rows: 1
-         :widths: 50 50 
+         :widths: 20 20 60
 
          * - Field
+           - Type
            - Description 
 
          * - ``metaField``
+           - string
            - The name of the field that contains metadata in each time series 
              document. The metadata in the specified field should be data that 
              is used to label a unique series of documents. 
 
          * - ``granularity``
+           - string 
            - Specifies a coarser granularity so measurements over a 
              longer time span can be more efficiently stored and queried.
 
@@ -61,10 +64,12 @@ Procedure
              ``bucketMaxSpanSeconds`` and ``bucketRoundingSeconds`` parameters.
 
          * - ``expireAfterSeconds``
+           - number
            -  Enables the automatic deletion of documents that are older than 
               the specified number of seconds.  
          
          * - ``bucketMaxSpanSeconds``
+           - number
            -  Specifies the maximum time span between measurements in a bucket. 
 
               The value of ``bucketMaxSpanSeconds`` must be the same as 
@@ -72,6 +77,7 @@ Procedure
               parameter, you can't set the ``granularity`` parameter.
 
          * - ``bucketRoundingSeconds``
+           - number
            -  Specifies the time interval that determines the starting timestamp 
               for a new bucket. 
 

--- a/source/collections/time-series-collection.txt
+++ b/source/collections/time-series-collection.txt
@@ -47,35 +47,33 @@ Procedure
            - Description 
 
          * - ``metaField``
-           - The name of the field which contains metadata in each time series 
+           - The name of the field that contains metadata in each time series 
              document. The metadata in the specified field should be data that 
              is used to label a unique series of documents. 
 
          * - ``granularity``
-           - The ``granularity`` field allows you to specify a coarser 
-             granularity so measurements over a longer time span can be more 
-             efficiently stored and queried.
+           - Lets you specify a coarser granularity so measurements over a 
+             longer time span can be more efficiently stored and queried.
 
-             The default value is set to ``seconds``.
+             The default value is set to ``"seconds"``.
 
              If you set the ``granularity`` parameter, you can't set the 
              ``bucketMaxSpanSeconds`` and ``bucketRoundingSeconds`` parameters.
 
          * - ``expireAfterSeconds``
-           -  The ``expireAfterSeconds`` field enables automatic deletion of 
-              documents older than the specified number of seconds.  
+           -  Enables the automatic deletion of documents that are older than 
+              the specified number of seconds.  
          
          * - ``bucketMaxSpanSeconds``
-           -  The ``bucketMaxSpanSeconds`` field specifies the maximum time span 
-              between measurements in a bucket. 
+           -  Specifies the maximum time span between measurements in a bucket. 
 
               The value of ``bucketMaxSpanSeconds`` must be the same as 
               ``bucketRoundingSeconds``. If you set the ``bucketMaxSpanSeconds``, 
               parameter, you can't set the ``granularity`` parameter.
 
          * - ``bucketRoundingSeconds``
-           -  The ``bucketRoundingSeconds`` field specifies the time interval 
-              that determines the starting timestamp for a new bucket. 
+           -  Specifies the time interval that determines the starting timestamp 
+              for a new bucket. 
 
               The value of ``bucketRoundingSeconds`` must be the same as 
               ``bucketMaxSpanSeconds``. If you set the ``bucketRoundingSeconds``, 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -32,7 +32,7 @@ versions of Compass to upgrade.
 
    If you are running macOS Catalina or later, you may have to modify
    your system settings to grant |compass-short| permission to run. For
-   more information, see :ref:`Install |compass-short| <compass-install>`.
+   more information, see :ref:`Install Compass <compass-install>`.
 
 .. _enable-automatic-updates:
 

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -32,7 +32,7 @@ versions of Compass to upgrade.
 
    If you are running macOS Catalina or later, you may have to modify
    your system settings to grant |compass-short| permission to run. For
-   more information, see :ref:`compass-install`.
+   more information, see :ref:`Install |compass-short| <compass-install>`.
 
 .. _enable-automatic-updates:
 


### PR DESCRIPTION
## DESCRIPTION
Add `bucketMaxSpanSeconds` and `bucketRoundingSeconds` fields to the Compass Create a Time Series Collection page.

**STANDING QUESTION(S)**
- For the table of fields, would it help to add a `Type` column that specifies what type of value is expected for each field, or do we expect the user to go the corresponding Server page for more details on that? 

## STAGING
https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-27956-buckmaxspanseconds-bucketroundingseconds/collections/time-series-collection/#specify-a-timefield.

## JIRA
https://jira.mongodb.org/browse/DOCSP-27966

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=63f7c92205dd3cc81464e278

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)