### PR TITLE
DOCSP-26725 Sample Configuration File option

### DIFF
--- a/source/config-file/config-file-options.txt
+++ b/source/config-file/config-file-options.txt
@@ -67,9 +67,8 @@ To view a sample |compass-short| configuration file, run the following command:
 
      <path-to-Compass-executable> --show-example-config
 
-If you do not already have a configuration file, you can use the following 
-command to create a configuration file that uses the sample configuration 
-settings:
+If you do not already have a configuration file, you can create a configuration 
+file that uses the sample configuration settings:
 
 .. code-block:: sh 
 

--- a/source/config-file/config-file-options.txt
+++ b/source/config-file/config-file-options.txt
@@ -68,11 +68,17 @@ To view a sample |compass-short| configuration file, run the following command:
      <path-to-Compass-executable> --show-example-config
 
 If you do not already have a configuration file, you can use the following 
-command to run |compass-short| with the sample configuration file: 
+command to create a configuration file that uses the sample configuration 
+settings:
 
 .. code-block:: sh 
 
      <path-to-Compass-executable> --show-example-config > /etc/mongodb-compass.conf
+
+.. seealso:: 
+
+  To run |compass-short| with a configuration file, see 
+  :ref:`compass-connect-file-based`.
 
 Learn More
 ----------

--- a/source/config-file/config-file-options.txt
+++ b/source/config-file/config-file-options.txt
@@ -74,11 +74,6 @@ file that uses the sample configuration settings:
 
      <path-to-Compass-executable> --show-example-config > /etc/mongodb-compass.conf
 
-.. seealso:: 
-
-  To run |compass-short| with a configuration file, see 
-  :ref:`compass-connect-file-based`.
-
 Learn More
 ----------
 

--- a/source/config-file/config-file-options.txt
+++ b/source/config-file/config-file-options.txt
@@ -59,6 +59,22 @@ You can configure the following settings in a configuration file:
      - Configure |compass| to not perform outgoing network operations other 
        than those to the database.
 
+Example 
+-------
+To view a sample |compass-short| configuration file, run the following command 
+in the folder containing your |compass| executable: 
+
+.. code-block:: sh
+
+     <path-to-Compass-executable> --show-example-config
+
+If you do not already have a configuration file, you can run the following 
+command to use the sample configuration file: 
+
+.. code-block:: sh 
+
+     <path-to-Compass-executable> --show-example-config > /etc/mongodb-compass.conf
+
 Learn More
 ----------
 

--- a/source/config-file/config-file-options.txt
+++ b/source/config-file/config-file-options.txt
@@ -61,15 +61,14 @@ You can configure the following settings in a configuration file:
 
 Example 
 -------
-To view a sample |compass-short| configuration file, run the following command 
-in the folder containing your |compass| executable: 
+To view a sample |compass-short| configuration file, run the following command: 
 
 .. code-block:: sh
 
      <path-to-Compass-executable> --show-example-config
 
-If you do not already have a configuration file, you can run the following 
-command to use the sample configuration file: 
+If you do not already have a configuration file, you can use the following 
+command to run |compass-short| with the sample configuration file: 
 
 .. code-block:: sh 
 


### PR DESCRIPTION
## DESCRIPTION
Adds information about sample configuration file that can be found with the `--show-example-config` flag.
Also notes command that can be run to use the sample config file (this information is found when you run --help).

**Note**: This content will likely be moved around in terms of placement during IA-change phase of this project.

## STAGING
https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-26725-sample-config-file/config-file/config-file-options/#example

## JIRA
https://jira.mongodb.org/browse/DOCSP-26725

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64065d37054271fb0ab49c3c

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)