### PR TITLE
DOCSP-26281 Add protectConnectionStrings option

### DIFF
--- a/source/config-file.txt
+++ b/source/config-file.txt
@@ -57,6 +57,8 @@ When you configure settings with a configuration file:
 Tasks
 -----
 
+- :ref:`compass-protect-connection-strings`
+
 - :ref:`compass-configure-network-traffic`
 
 - :ref:`specify-read-preference-tags`
@@ -69,5 +71,6 @@ Tasks
    :titlesonly:
 
    /config-file/config-file-options
+   /config-file/protect-connection-strings
    /config-file/restrict-outgoing-connections
    /config-file/specify-read-preference-tags

--- a/source/config-file/config-file-options.txt
+++ b/source/config-file/config-file-options.txt
@@ -61,6 +61,9 @@ You can configure the following settings in a configuration file:
    * - :ref:`networkTraffic <compass-configure-network-traffic>`
      - Configure |compass| to not perform outgoing network operations other 
        than those to the database.
+   
+   * - :ref:`protectConnectionStrings <compass-protect-connection-strings>`
+     - .. include:: /includes/fact-protect-connection-strings.rst 
 
 Example 
 -------

--- a/source/config-file/protect-connection-strings.txt
+++ b/source/config-file/protect-connection-strings.txt
@@ -1,0 +1,70 @@
+.. _compass-protect-connection-strings:
+
+==========================================
+Hide Credentials in Your Connection String 
+==========================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+You can use the ``protectConnectionStrings`` option to hide credentials when 
+users connect to |compass-short| with a connection string. When 
+``protectConnectionStrings`` is enabled, users cannot edit hidden credentials 
+in the |compass-short| connection form, copy the connection string in the 
+|compass-short| interface, or see the credentials when using the :ref:`Export 
+to Language <compass-export-query>` functionality. 
+
+Procedure
+---------
+
+To protect your connection string credentials, enable the 
+``protectConnectionStrings`` option. You can set this option in the 
+|compass-short| :guilabel:`Settings` panel, on the command line or in a 
+:ref:`configuration file <config-file>`. 
+
+Command Line Example
+~~~~~~~~~~~~~~~~~~~~
+
+The following command starts |compass| from the command line and sets
+the ``--protectConnectionStrings`` option:
+
+.. code-block:: sh
+
+   <path-to-Compass-executable> --protectConnectionStrings
+
+.. note::
+
+  The name and filepath of the |compass-short| executable depend on your
+  operating system.
+
+Configuration File Example
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can specify the |compass-short| configuration file in either EJSON
+or YAML format. The following configurations set the 
+``protectConnectionStrings`` option to ``true``:
+
+EJSON
+`````
+
+.. code-block:: json
+
+   { "protectConnectionStrings": true }
+
+YAML
+````
+
+.. code-block:: yaml
+
+   protectConnectionStrings: true
+
+Learn More
+----------
+
+To learn more about the |compass| configuration file, see
+:ref:`config-file`.

--- a/source/config-file/protect-connection-strings.txt
+++ b/source/config-file/protect-connection-strings.txt
@@ -13,25 +13,40 @@ Hide Credentials in Your Connection String
    :depth: 2
    :class: singlecol
 
-You can use the ``protectConnectionStrings`` option to hide credentials when 
-users connect to |compass-short| with a connection string. When 
-``protectConnectionStrings`` is enabled, users cannot edit hidden credentials 
-in the |compass-short| connection form, copy the connection string in the 
-|compass-short| interface, or see the credentials when using the :ref:`Export 
-to Language <compass-export-query>` functionality. 
+When you paste a connection string into the |compass| connection form, by
+default, |compass-short| shows credentials in plaintext. To hide credentials in 
+the connection string, use the ``protectConnectionStrings`` option. 
+
+About This Task
+---------------
+
+When ``protectConnectionStrings`` is enabled, users cannot perform the following 
+actions: 
+
+- Edit the connection string in the |compass-short| connection form 
+
+- Copy the connection string in the |compass-short| interface 
+
+- See the credentials when :ref:`exporting a query <compass-export-query>`. 
 
 Procedure
 ---------
 
-To protect your connection string credentials, enable the 
-``protectConnectionStrings`` option. You can set this option in the 
-|compass-short| :guilabel:`Settings` panel, on the command line or in a 
-:ref:`configuration file <config-file>`. 
+To hide your your connection string credentials, enable the 
+``protectConnectionStrings`` option. 
+
+You can set this option in either: 
+
+- The |compass-short| :guilabel:`Settings` panel
+
+- The :ref:`command line <cli-options>`
+
+- A :ref:`configuration file <config-file>`
 
 Command Line Example
 ~~~~~~~~~~~~~~~~~~~~
 
-The following command starts |compass| from the command line and sets
+The following command starts |compass-short| from the command line and sets
 the ``--protectConnectionStrings`` option:
 
 .. code-block:: sh

--- a/source/config-file/protect-connection-strings.txt
+++ b/source/config-file/protect-connection-strings.txt
@@ -1,4 +1,5 @@
 .. _compass-protect-connection-strings:
+.. _hide-connection-string-credentials:
 
 ==========================================
 Hide Credentials in Your Connection String 

--- a/source/config-file/protect-connection-strings.txt
+++ b/source/config-file/protect-connection-strings.txt
@@ -27,7 +27,7 @@ actions:
 
 - Copy the connection string in the |compass-short| interface 
 
-- See the credentials when :ref:`exporting a query <compass-export-query>`. 
+- See the credentials when :ref:`exporting a query <compass-export-query>`
 
 Procedure
 ---------

--- a/source/config-file/protect-connection-strings.txt
+++ b/source/config-file/protect-connection-strings.txt
@@ -13,8 +13,8 @@ Hide Credentials in Your Connection String
    :depth: 2
    :class: singlecol
 
-When you paste a connection string into the |compass| connection form, by
-default, |compass-short| shows credentials in plaintext. To hide credentials in 
+When you paste a connection string into the |compass| connection form, 
+|compass-short| shows credentials in plaintext by default. To hide credentials in 
 the connection string, use the ``protectConnectionStrings`` option. 
 
 About This Task
@@ -23,11 +23,11 @@ About This Task
 When ``protectConnectionStrings`` is enabled, users cannot perform the following 
 actions: 
 
-- Edit the connection string in the |compass-short| connection form 
+- Edit the connection string in the |compass-short| connection form. 
 
-- Copy the connection string in the |compass-short| interface 
+- Copy the connection string in the |compass-short| interface. 
 
-- See the credentials when :ref:`exporting a query <compass-export-query>`
+- See the credentials when :ref:`exporting a query <compass-export-query>`.
 
 Procedure
 ---------
@@ -35,7 +35,7 @@ Procedure
 To hide your your connection string credentials, enable the 
 ``protectConnectionStrings`` option. 
 
-You can set this option in either: 
+You can set the ``protectConnectionStrings`` option in either: 
 
 - The |compass-short| :guilabel:`Settings` panel
 

--- a/source/connect/connect-from-the-command-line/command-line-options.txt
+++ b/source/connect/connect-from-the-command-line/command-line-options.txt
@@ -114,8 +114,7 @@ value in the :guilabel:`Settings` panel.
 
 .. option:: --protectConnectionStrings
 
-   Hide credentials in connection strings. Passwords in connection 
-   strings are displayed as ``*****``. 
+   .. include:: /includes/fact-protect-connection-strings.rst  
 
 .. option:: --theme
 

--- a/source/connect/connect-from-the-command-line/command-line-options.txt
+++ b/source/connect/connect-from-the-command-line/command-line-options.txt
@@ -106,15 +106,21 @@ value in the :guilabel:`Settings` panel.
 .. option:: --forceConnectionOptions
 
    .. include:: /includes/fact-force-connection-options.rst
+      
+   To learn more, see :ref:`compass-force-connection-options`.
 
 .. option:: --networkTraffic
 
    Configure |compass| to only allow outgoing :ref:`network operations 
    <compass-configure-network-traffic>` to connect to the database. 
 
+   To learn more, see :ref:`compass-configure-network-traffic`.
+
 .. option:: --protectConnectionStrings
 
    .. include:: /includes/fact-protect-connection-strings.rst  
+   
+   To learn more, see :ref:`compass-protect-connection-strings`.
 
 .. option:: --theme
 

--- a/source/includes/fact-protect-connection-strings.rst
+++ b/source/includes/fact-protect-connection-strings.rst
@@ -1,0 +1,2 @@
+Hide credentials in your connection string. Passwords in connection 
+strings are displayed as ``*****``


### PR DESCRIPTION
## DESCRIPTION
- Moved existing description of `protectConnectionStrings` options to an include. 
- Created task page for enabling `protectConnectionStrings` in the CLI and config file. 

**Note:** The instructions for enabling this setting on the Settings UI will be documented in a soon-to-follow ticket.

## STAGING
- [Added to list of Tasks on Config File Options page](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-26281-protectconnectionstrings-option/config-file/#tasks)
- [Hide Credentials, Task Page](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-26281-protectconnectionstrings-option/config-file/protect-connection-strings/)
- [Config File Options](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-26281-protectconnectionstrings-option/config-file/config-file-options/#settings)
- [Command Line Options](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-26281-protectconnectionstrings-option/connect/connect-from-the-command-line/command-line-options/#std-option-compass.--protectConnectionStrings)

## JIRA
https://jira.mongodb.org/browse/DOCSP-26281

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6412314cb070a41637af95fd

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)