### PR TITLE
DOCSP-27560/DOCSP-27560 Compass RN 1.36.0 and 1.36.1

### DIFF
--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -10,6 +10,55 @@ Release Notes
    :depth: 1
    :class: twocols
 
+|compass| 1.36.0
+----------------
+
+*Released March 14, 2023*
+
+New Features:
+
+- Add stage button between stages (:issue:`COMPASS-6382`)
+- Use type from last array element when inserting new element to array 
+  (:issue:`COMPASS-6432`)
+- Redirect to the new collection after creating it (:issue:`COMPASS-6019`)
+- Stage toolbar (:issue:`COMPASS-6381`)
+- LG darkmode support and UI cleanup in the explain tab (:issue:`COMPASS-6463`)
+- Adds a cancellable loader to explain
+- Enable column store indexes for MongoDB 6.3 (:issue:`COMPASS-6487`)
+- flexi bucket options for Timeseries
+- Upgrade mongosh to 1.7.0
+- Include preview rows in the listCSVFields() result (:issue:`COMPASS-6422`)
+- Enable focus mode (:issue:`COMPASS-6474`)
+- When dropping a collection or database, redirect to either the database or 
+  databases view (:issue:`COMPASS-6018`, :issue:`COMPASS-6434`)
+- Dark theme improvements in the settings modal (:issue:`COMPASS-6552`)
+- Conditional confirmation modal (:issue:`COMPASS-6355`)
+- Adds the refresh CTA to sidebar
+- Open file input before import modal (:issue:`COMPASS-6535`)
+- Enable LG darkmode as public preview (:issue:`COMPASS-6515`, 
+  :issue:`COMPASS-6556`)
+- Hook for keyboard shortcuts (:issue:`COMPASS-6551`)
+- Adds refresh CTA on database and collection list view (:issue:`COMPASS-6431`)
+- Place settings under the most idiomatic menu for the platform 
+  (:issue:`COMPASS-6430`)
+
+Bug Fixes:
+
+- If a date is in the safe range, go with relaxed EJSON rather than canonical 
+  (:issue:`COMPASS-5744`)
+- Redesign of add stage button (:issue:`COMPASS-6449`)
+- Optimises the opening of tab
+- Don't show negative count on delete when no document count (:issue:`COMPASS-5996`)
+- Stop on errors when stopOnErrors is true (:issue:`COMPASS-6518`)
+- Undefined rather than false if getCloudInfo fails, support SRV URIs 
+  (:issue:`COMPASS-6111`)
+- Cancel edit on non-existent field (:issue:`COMPASS-6505`)
+- Halt autoupdater on application exit to prevent logger crashing 
+  (:issue:`COMPASS-6051`)
+- Do not reset stage value if it was already changed (:issue:`COMPASS-6584`)
+
+`Full Changelog available on Github: v1.35.0...v1.36.0 
+<https://github.com/mongodb-js/compass/compare/v1.35.0...v1.36.0>``
 
 |compass| 1.35.0
 ----------------

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -58,7 +58,7 @@ Bug Fixes:
 - Do not reset stage value if it was already changed (:issue:`COMPASS-6584`)
 
 `Full Changelog available on Github: v1.35.0...v1.36.0 
-<https://github.com/mongodb-js/compass/compare/v1.35.0...v1.36.0>``
+<https://github.com/mongodb-js/compass/compare/v1.35.0...v1.36.0>`__
 
 |compass| 1.35.0
 ----------------

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -10,7 +10,7 @@ Release Notes
    :depth: 1
    :class: twocols
 
-|compass| 1.36.1
+|compass| 1.36.0
 ----------------
 
 *Released March 15, 2023*
@@ -18,18 +18,6 @@ Release Notes
 New Features:
 
 - Enable focus mode (:issue:`COMPASS-6474`)
-
-`Full Changelog is available on GitHub 
-<https://github.com/mongodb-js/compass/compare/v1.36.0...v1.36.1>`__
-
-
-|compass| 1.36.0
-----------------
-
-*Released March 14, 2023*
-
-New Features:
-
 - Add stage button between stages (:issue:`COMPASS-6382`)
 - Use type from last array element when inserting new element to array 
   (:issue:`COMPASS-6432`)

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -10,6 +10,19 @@ Release Notes
    :depth: 1
    :class: twocols
 
+|compass| 1.36.1
+----------------
+
+*Released March 15, 2023*
+
+New Features:
+
+- Enable focus mode (:issue:`COMPASS-6474`)
+
+`Full Changelog is available on GitHub 
+<https://github.com/mongodb-js/compass/compare/v1.36.0...v1.36.1>`__
+
+
 |compass| 1.36.0
 ----------------
 

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -70,7 +70,7 @@ Bug Fixes:
   (:issue:`COMPASS-6051`)
 - Do not reset stage value if it was already changed (:issue:`COMPASS-6584`)
 
-`Full Changelog available on Github: v1.35.0...v1.36.0 
+`Full Changelog available on Github:
 <https://github.com/mongodb-js/compass/compare/v1.35.0...v1.36.0>`__
 
 |compass| 1.35.0


### PR DESCRIPTION
## DESCRIPTION

Adds release notes for 1.36.0 and 1.36.1.

## STAGING

* [Release Notes](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-27560-compass-rn-1.36.0/release-notes/)

## JIRA

* [DOCSP-27560](https://jira.mongodb.org/browse/DOCSP-27560)

* [DOCSP-28596](https://jira.mongodb.org/browse/DOCSP-28596)

## BUILD LOG
[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=641358e7b070a41637f078f2)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)