### PR TITLE
DOCSP-28333 Remove Redundant Example on Agg Pipeline Builder Page

### DIFF
--- a/source/aggregation-pipeline-builder.txt
+++ b/source/aggregation-pipeline-builder.txt
@@ -567,54 +567,6 @@ To update the :guilabel:`count results`:
       .. figure:: /images/compass/agg-builder-show-document-count.png
          :alt: Show current document counts
 
-Example
--------
-
-In this example, you create and run a pipeline
-for a collection with airline data. You can download this
-dataset from the following link:
-`air_airlines.json <https://raw.githubusercontent.com/mongodb/docs-assets/compass/air_airlines.json>`__.
-
-For instructions on importing JSON data into your cluster, see :ref:`Import Data 
-into a Collection <import-data>`. This example assumes you have the data in the
-``example.air_airlines`` namespace.
-
-Procedure
-~~~~~~~~~
-
-1. Connect to a database deployment. For information on how to connect to a 
-   database deployment, see :atlas:`Connect via Compass </compass-connection/>`.
-
-#. Select the ``example`` database where the ``air_airlines`` collection 
-   exists. 
-
-#. Create the Pipeline
-
-   |
-
-   The following pipeline has two aggregation stages:
-   :pipeline:`$group` and :pipeline:`$match`.
-
-   - The ``$group`` stage groups documents by their
-     ``active`` status and ``country``. The stage also adds
-     a new ``flightCount`` field containing the number
-     of documents in each group.
-
-   - The ``$match`` stage filters documents to return documents
-     with a ``flightCount`` value greater than or equal to ``5``.
-
-     .. figure:: /images/compass/agg-builder-full-example.png
-        :alt: Aggregation Builder Full Example
-
-#. Run the Pipeline.
-
-   Click :guilabel:`Run` at the top right of the pipeline builder.
-
-The pipeline returns documents, as shown in the following abbreviated example:
-
-.. figure:: /images/compass/airline-example-results.png
-   :alt: Airline Pipeline Results
-
 .. toctree::
    :titlesonly:
    


### PR DESCRIPTION
## DESCRIPTION
Removes Example section from Aggregation Pipeline Builder page. 
- Reasoning: Example, as is, doesn't provide any new or especially insightful information for users that can't be found elsewhere on the page. 

## STAGING
https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-28333-agg-pipeline-example/aggregation-pipeline-builder/#refresh-document-counts

## JIRA
https://jira.mongodb.org/browse/DOCSP-28333

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=641b191db070a41637742727

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)