### PR TITLE
DOCSP-26539 protectConnectionStrings in settings UI

### DIFF
--- a/source/settings/protect-connection-strings.txt
+++ b/source/settings/protect-connection-strings.txt
@@ -43,6 +43,30 @@ You can set the ``protectConnectionStrings`` option in either:
 
 - A :ref:`configuration file <config-file>`
 
+|compass-short| Settings Panel
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. procedure:: 
+   :style: normal
+   
+   .. step:: In the |compass-short| top menu bar, click :guilabel:`MongoDB Compass`. 
+      
+      Alternatively, you can use keyboard shortcuts to open the 
+      :guilabel:`Settings` panel: 
+      
+      - Windows / Linux: ``Ctrl`` + ``,``
+      
+      - Mac: ``⌘`` + ``,``
+
+   .. step:: In the :guilabel:`MongoDB Compass` menu, click :guilabel:`Settings`.
+
+      |compass-short| opens a dialog box where you can configure your |compass| 
+      settings.
+
+   .. step:: Toggle :guilabel:`Protect Connection String Secrets`.
+
+   .. step:: Click :guilabel:`Save`.
+
 Command Line Example
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/source/settings/protect-connection-strings.txt
+++ b/source/settings/protect-connection-strings.txt
@@ -50,6 +50,10 @@ You can set the ``protectConnectionStrings`` option in either:
    :style: normal
    
    .. step:: In the |compass-short| top menu bar, click :guilabel:`MongoDB Compass`. 
+
+      .. figure:: /images/compass/settings-panel-location.png
+         :scale: 60% 
+         :alt: Settings panel location under the MongoDB Compass system menu
       
       Alternatively, you can use keyboard shortcuts to open the 
       :guilabel:`Settings` panel: 


### PR DESCRIPTION
## DESCRIPTION
Add steps for setting `protectConnectionStrings` in the Compass settings UI to existing task page. 

## STAGING
- [Entry in Settings table](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-26539-protectconnectionstrings-ui/settings/settings-reference/#settings)
- [Settings UI Procedures](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-26539-protectconnectionstrings-ui/settings/protect-connection-strings/#compass-short-settings-panel)

## JIRA
https://jira.mongodb.org/browse/DOCSP-26539

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6421d3f2b070a41637c4b912

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)