### PR TITLE
DOCSP-26520 readOnly Settings

### DIFF
--- a/source/settings.txt
+++ b/source/settings.txt
@@ -43,6 +43,8 @@ Tasks
 
 - :ref:`compass-protect-connection-strings`
 
+- :ref:`compass-read-only`
+
 - :ref:`compass-force-connection-options`
 
 - :ref:`compass-enable-dev-tools`

--- a/source/settings.txt
+++ b/source/settings.txt
@@ -66,5 +66,6 @@ Learn more
    /settings/config-file
    /settings/restrict-outgoing-connections
    /settings/protect-connection-strings
+   /settings/read-only
    /settings/specify-read-preference-tags
    /settings/enable-dev-tools

--- a/source/settings/read-only.txt
+++ b/source/settings/read-only.txt
@@ -20,8 +20,10 @@ rules.
 About This Task 
 ---------------
 
-If ``readOnly`` is enabled, |compass-short| automatically disables the 
-following options: 
+By default, |compass-short| disables :guilabel:`Set Read-Only Mode`.
+
+If :guilabel:`Set Read-Only Mode` is enabled, |compass-short| automatically 
+disables the following options: 
 
 - :guilabel:`Enable MongoDB Shell`
 - :guilabel:`Enable DevTools`

--- a/source/settings/read-only.txt
+++ b/source/settings/read-only.txt
@@ -1,0 +1,109 @@
+.. _compass-read-only:
+
+====================================
+Restrict Write Operations to MongoDB
+====================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+You can use the ``readOnly`` option to prevent users from performing write 
+operations to MongoDB thorugh |compass-short|. If you set the ``readOnly`` 
+option, users cannot modify documents, create indexes, or specify validation 
+rules.
+
+About This Task 
+---------------
+
+If ``readOnly`` is enabled, |compass-short| automatically disables the 
+following options: 
+
+- :guilabel:`Enable MongoDB Shell`
+- :guilabel:`Enable DevTools`
+
+Procedure
+---------
+
+You can set the ``readOnly`` option in either: 
+
+- The |compass-short| :ref:`Settings panel <compass-settings-reference>`
+
+- The :ref:`command line <cli-options>`
+
+- A :ref:`configuration file <config-file>`
+
+|compass-short| Settings Panel
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. procedure:: 
+   :style: normal
+   
+   .. step:: In the |compass-short| top menu bar, click :guilabel:`MongoDB Compass`. 
+
+      .. figure:: /images/compass/settings-panel-location.png
+         :scale: 60% 
+         :alt: Settings panel location under the MongoDB Compass system menu
+      
+      Alternatively, you can use keyboard shortcuts to open the 
+      :guilabel:`Settings` panel: 
+      
+      - Windows / Linux: ``Ctrl`` + ``,``
+      
+      - Mac: ``⌘`` + ``,``
+
+   .. step:: In the :guilabel:`MongoDB Compass` menu, click :guilabel:`Settings`.
+
+      |compass-short| opens a dialog box where you can configure your |compass| 
+      settings.
+
+   .. step:: Toggle :guilabel:`Set Read-Only Mode`.
+
+   .. step:: Click :guilabel:`Save`.
+
+Command Line
+~~~~~~~~~~~~
+
+The following command starts |compass-short| from the command line and sets
+the ``--readOnly`` option:
+
+.. code-block:: sh
+
+   <path-to-Compass-executable> --readOnly
+
+.. note::
+
+  The name and filepath of the |compass-short| executable depend on your
+  operating system.
+
+Configuration File
+~~~~~~~~~~~~~~~~~~
+
+You can specify the |compass-short| configuration file in either EJSON
+or YAML format. The following configurations set the 
+``readOnly`` option to ``true``:
+
+EJSON
+`````
+
+.. code-block:: json
+
+   { "readOnly": true }
+
+YAML
+````
+
+.. code-block:: yaml
+
+   readOnly: true
+
+Learn More
+----------
+
+To learn more about the |compass| configuration file, see
+:ref:`config-file`.
+

--- a/source/settings/read-only.txt
+++ b/source/settings/read-only.txt
@@ -13,25 +13,25 @@ Restrict Write Operations to MongoDB
    :class: singlecol
 
 You can use the ``readOnly`` option to prevent users from performing write 
-operations to MongoDB thorugh |compass-short|. If you set the ``readOnly`` 
-option, users cannot modify documents, create indexes, or specify validation 
-rules.
+operations to your MongoDB deployment through |compass-short|. If you enable the 
+``readOnly`` option, users cannot modify documents, create indexes, or specify 
+validation rules.
 
 About This Task 
 ---------------
 
-By default, |compass-short| disables :guilabel:`Set Read-Only Mode`.
+By default, |compass-short| disables the ``readOnly`` option.
 
-If :guilabel:`Set Read-Only Mode` is enabled, |compass-short| automatically 
-disables the following options: 
+If the ``readOnly`` option is enabled, |compass-short| you cannot enable the 
+following options: 
 
-- :guilabel:`Enable MongoDB Shell`
-- :guilabel:`Enable DevTools`
+- :ref:`enableShell <embedded-mongodb-shell>`
+- ``enableDevtools``
 
 Procedure
 ---------
 
-You can set the ``readOnly`` option in either: 
+You can enable the ``readOnly`` option in either: 
 
 - The |compass-short| :ref:`Settings panel <compass-settings-reference>`
 

--- a/source/settings/read-only.txt
+++ b/source/settings/read-only.txt
@@ -22,8 +22,7 @@ About This Task
 
 By default, |compass-short| disables the ``readOnly`` option.
 
-If the ``readOnly`` option is enabled, |compass-short| you cannot enable the 
-following options: 
+If the ``readOnly`` option is enabled, you cannot enable the following options: 
 
 - :ref:`enableShell <embedded-mongodb-shell>`
 - ``enableDevtools``

--- a/source/settings/read-only.txt
+++ b/source/settings/read-only.txt
@@ -25,7 +25,7 @@ By default, |compass-short| disables the ``readOnly`` option.
 If the ``readOnly`` option is enabled, you cannot enable the following options: 
 
 - :ref:`enableShell <embedded-mongodb-shell>`
-- ``enableDevtools``
+- :ref:`enableDevtools <compass-enable-dev-tools>`
 
 Procedure
 ---------

--- a/source/settings/settings-reference.txt
+++ b/source/settings/settings-reference.txt
@@ -54,6 +54,8 @@ You can configure the following settings on the |compass| interface:
      - General
      - Remove all write and delete capabilities on |compass-short|. 
 
+       To learn more, see :ref:`compass-read-only`.
+
    * - Enable MongoDB Shell
      - General
      - Enable or disable the embedded MongoDB Shell on |compass-short|. 


### PR DESCRIPTION
## DESCRIPTION
- Add task page for setting `readOnly` option
- Add to task list in Settings concept + reference pages

## STAGING
- [New task page](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-26520-readonly-setting/settings/read-only/)
- [Task list on concept page](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-26520-readonly-setting/settings/#tasks)
- [Reference page table entry](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-26520-readonly-setting/settings/settings-reference/#:~:text=Definition-,Set%20Read%2DOnly%20Mode,-General)

## JIRA
https://jira.mongodb.org/browse/DOCSP-26520

## BUILD LOG
UPDATED: https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=642af2a666f244bf57b7f10a

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)