### PR TITLE
DOCSP-26694 Remove Information about Crash Report Collection

### DIFF
--- a/source/embedded-shell.txt
+++ b/source/embedded-shell.txt
@@ -79,9 +79,9 @@ To disable the embedded MongoDB shell:
 .. procedure::
    :style: normal
 
-   .. step:: In the |compass-short| top menu bar, click :guilabel:`Help`.
+   .. step:: In the |compass-short| top menu bar, click :guilabel:`MongoDB Compass`.
 
-   .. step:: In the :guilabel:`Help` menu, click :guilabel:`Settings`.
+   .. step:: In the :guilabel:`MongoDB Compass` menu, click :guilabel:`Settings`.
       
       |compass-short| opens a dialog box where you configure your |compass| 
       settings.

--- a/source/faq.txt
+++ b/source/faq.txt
@@ -133,12 +133,12 @@ How do I view and modify my Privacy Settings?
 To view and modify your |compass| privacy settings, from the top-level
 menu:
 
-1. Click :guilabel:`Help`.
+1. Click :guilabel:`MongoDB Compass`.
 #. Click :guilabel:`Settings`.
 #. Under :guilabel:`Settings`, click :guilabel:`Privacy`.
 
 The privacy settings dialog allows you to toggle various
-|compass| settings such as enabling crash reports and automatic updates.
+|compass| settings such as enabling automatic updates.
 See the following screenshot for all available privacy settings options:
 
 .. figure:: /images/compass/privacy-settings.png
@@ -147,8 +147,7 @@ See the following screenshot for all available privacy settings options:
 
 .. note::
 
-   Crash reports and automatic updates are not available in
-   :guilabel:`Compass Isolated Edition`.
+   Automatic updates are not available in :guilabel:`Compass Isolated Edition`.
 
 How do I enable geographic visualizations?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/settings/command-line-options.txt
+++ b/source/settings/command-line-options.txt
@@ -126,11 +126,6 @@ value in the :guilabel:`Settings` panel.
    Specify the |compass| UI theme. The supported themes are ``DARK``,
    ``LIGHT``, and ``OS_THEME``.
    
-.. option:: --trackErrors
-
-   Enable sending crash reports. Use ``--no-trackErrors`` to disable
-   sending crash reports.
-   
 .. option:: --trackUsageStatistics
 
    Enable sending usage statistics. Use ``--no-trackUsageStatistics``

--- a/source/upgrade.txt
+++ b/source/upgrade.txt
@@ -40,7 +40,8 @@ Enable Automatic Updates
 ------------------------
 
 You can enable automatic updates to the latest version of Compass in the 
-:guilabel:`Privacy` section of the :guilabel:`Help > Settings` dialog.
+:guilabel:`Privacy` section of the :guilabel:`MongoDB Compass > Settings` 
+dialog.
 
 .. figure:: /images/compass/privacy-settings.png
    :scale: 80%


### PR DESCRIPTION
## DESCRIPTION
Removes information about now-removed Crash Report collection option. 
Also edited some incorrect settings procedures I happened to catch along the way.

## STAGING
- [FAQ](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-26694-remove-crash-report-collection-option/faq/#how-do-i-view-and-modify-my-privacy-settings-)
- [Command Line Settings ](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-26694-remove-crash-report-collection-option/settings/command-line-options/#general-settings)

## JIRA
https://jira.mongodb.org/browse/DOCSP-26694

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=642dd6a2b49106a498ae7e66

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)