### PR TITLE
DOCSP-26724 Register Compass as a Protocol Handler

### DIFF
--- a/source/settings/settings-reference.txt
+++ b/source/settings/settings-reference.txt
@@ -86,6 +86,15 @@ You can configure the following settings on the |compass| interface:
 
        To learn more, see :ref:`compass-enable-dev-tools`.
 
+   * - Install |compass-short| as URL Protocol Handler
+     - General
+     - Register |compass-short| as a handler for mongodb:// and mongodb+srv:// 
+       URLs. 
+
+       If :guilabel:`Install Compass as URL Protocol Handler` is enabled, 
+       you can open |compass-short| by navigating to a mongodb:// or 
+       mongodb+srv:// URL.
+
    * - Sync with OS
      - Theme 
      - Automatically switch between light and dark themes based on your OS 

--- a/source/settings/settings-reference.txt
+++ b/source/settings/settings-reference.txt
@@ -95,7 +95,8 @@ You can configure the following settings on the |compass| interface:
        you can open |compass-short| by navigating to a mongodb:// or 
        mongodb+srv:// URL in your browser.
 
-        *Available on macOS and Windows.*
+       By default, :guilabel:`Install Compass as URL Protocol Handler` is 
+       enabled, but you can toggle this setting only on Windows or macOS.
 
    * - Sync with OS
      - Theme 

--- a/source/settings/settings-reference.txt
+++ b/source/settings/settings-reference.txt
@@ -93,7 +93,7 @@ You can configure the following settings on the |compass| interface:
 
        If :guilabel:`Install Compass as URL Protocol Handler` is enabled, 
        you can open |compass-short| by navigating to a mongodb:// or 
-       mongodb+srv:// URL.
+       mongodb+srv:// URL in your browser.
 
         *Available on macOS and Windows.*
 

--- a/source/settings/settings-reference.txt
+++ b/source/settings/settings-reference.txt
@@ -96,7 +96,8 @@ You can configure the following settings on the |compass| interface:
        mongodb+srv:// URL in your browser.
 
        By default, :guilabel:`Install Compass as URL Protocol Handler` is 
-       enabled. You can toggle this setting only on Windows or macOS.
+       enabled. You cannot toggle this option on Linux. You can toggle this 
+       setting only on Windows or macOS.
 
    * - Sync with OS
      - Theme 

--- a/source/settings/settings-reference.txt
+++ b/source/settings/settings-reference.txt
@@ -96,7 +96,7 @@ You can configure the following settings on the |compass| interface:
        mongodb+srv:// URL in your browser.
 
        By default, :guilabel:`Install Compass as URL Protocol Handler` is 
-       enabled, but you can toggle this setting only on Windows or macOS.
+       enabled. You can toggle this setting only on Windows or macOS.
 
    * - Sync with OS
      - Theme 

--- a/source/settings/settings-reference.txt
+++ b/source/settings/settings-reference.txt
@@ -95,6 +95,8 @@ You can configure the following settings on the |compass| interface:
        you can open |compass-short| by navigating to a mongodb:// or 
        mongodb+srv:// URL.
 
+        *Available on macOS and Windows.*
+
    * - Sync with OS
      - Theme 
      - Automatically switch between light and dark themes based on your OS 


### PR DESCRIPTION
## DESCRIPTION
- Adds `installURLHandlers` to settings reference page
- No task page associated with this because the setting is enabled by default and the desired use case is that a user would want to keep it enabled. 

## STAGING
https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-26724-compass-protocol-handler/settings/settings-reference/#:~:text=Chrome%20DevTools.-,Install%20Compass%20as%20URL%20Protocol%20Handler,-General

## JIRA
https://jira.mongodb.org/browse/DOCSP-26724

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=642f0f40b49106a498f0d4a7

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)