### PR TITLE
DOCSP-29045 reference page updates

### DIFF
--- a/source/settings/config-file/config-file-options.txt
+++ b/source/settings/config-file/config-file-options.txt
@@ -55,8 +55,36 @@ You can configure the following settings in a configuration file:
    * - Setting 
      - Definition
 
+   * - autoUpdates
+     - Allow |compass-short| to periodically check for new updates.
+
+   * - :ref:`enableDevtools <compass-enable-dev-tools>`
+     - Enable Chrome DevTools in |compass-short|.
+
+   * - enableMaps
+     - Allow |compass-short| to make requests to third-party mapping services.
+
+   * - :ref:`enableShell <disable-shell>`
+     - Enable or disable the embedded MongoDB Shell on |compass-short|.
+
    * - :ref:`forceConnectionOptions <compass-force-connection-options>`
      - .. include:: /includes/fact-force-connection-options.rst
+    
+   * - ignoreAdditionalCommandLineFlags 
+     - Allow or disallow additional command-line option flags.
+
+   * - installURLHandlers 
+     - Register |compass-short| as a handler for mongodb:// and mongodb+srv:// 
+       URLs. 
+
+       If :guilabel:`Install Compass as URL Protocol Handler` is enabled, 
+       you can open |compass-short| by navigating to a mongodb:// or 
+       mongodb+srv:// URL in your browser.
+
+       *Available on macOS and Windows.*
+
+   * - maxTimeMS 
+     - Specify an upper time limit for all |compass-short| database operations.
 
    * - :ref:`networkTraffic <compass-configure-network-traffic>`
      - Configure |compass| to not perform outgoing network operations other 
@@ -64,6 +92,21 @@ You can configure the following settings in a configuration file:
    
    * - :ref:`protectConnectionStrings <compass-protect-connection-strings>`
      - .. include:: /includes/fact-protect-connection-strings.rst 
+
+   * - :ref:`readOnly <compass-read-only>`
+     - Prevent users from performing write operations to your MongoDB deployment 
+       through |compass-short|.
+
+   * - :ref:`showKerberosPasswordField <compass-kerberos-password>`
+     - Show or hide the Kerberos password field on the |compass-short| 
+       connection form.
+    
+   * - theme
+     - Specify the |compass| UI theme. The supported themes are ``DARK``,
+       ``LIGHT``, and ``OS_THEME``.
+
+   * - trackUsageStatistics
+     - Allow |compass-short| to send anonymous usage statistics.
 
 Example 
 -------

--- a/source/settings/config-file/config-file-options.txt
+++ b/source/settings/config-file/config-file-options.txt
@@ -79,7 +79,7 @@ You can configure the following settings in a configuration file:
 
        If :guilabel:`Install Compass as URL Protocol Handler` is enabled, 
        you can open |compass-short| by navigating to a mongodb:// or 
-       mongodb+srv:// URL in your browser.
+       mongodb+srv:// URL in your internet browser.
 
        *Available on macOS and Windows.*
 

--- a/source/settings/config-file/config-file-options.txt
+++ b/source/settings/config-file/config-file-options.txt
@@ -50,7 +50,7 @@ You can configure the following settings in a configuration file:
 
 .. list-table::
    :header-rows: 1
-   :widths: 30 70
+   :widths: 40 60
 
    * - Setting 
      - Definition


### PR DESCRIPTION
## DESCRIPTION
Update reference table of configuration options.
Note: The build error/missing ref will be resolved once #480 is merged.

## STAGING
https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-29045-reference-page-updates/settings/config-file/config-file-options/#settings

## JIRA
https://jira.mongodb.org/browse/DOCSP-29045

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64342f64b49106a498d7cdbe

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)