### PR TITLE
DOCSP-28851 Adds release notes for Compass 1.36.2

### DIFF
--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -28,6 +28,32 @@ Bug Fixes:
 - Remove count when exporting views and time series collections 
   (:issue:`COMPASS-5179`, :issue:`COMPASS-6649`)
 
+|compass| 1.36.2
+-----------------
+
+*Released March 29, 2023*
+
+New Features:
+
+- Removes focus mode feature flag, always show (:issue:`COMPASS-6474`)
+- Analyze CSV fields and auto-select the correct type (:issue:`COMPASS-6536`)
+- Add GitHub source code link to help menu and window menu
+  (:issue:`COMPASS-6585`)
+- Makes analyzeCSVFields() skippable (:issue:`COMPASS-6638`)
+
+Bug Fixes:
+
+- Apply readPref to initial ping command (:issue:`COMPASS-6595`)
+- Fix guessFileType() for large JSON docs (:issue:`COMPASS-6629`)
+- Fix memory leak in listCSVFields() (:issue:`COMPASS-6630`)
+- Add dark mode colours for the mixed warning
+- Abort analyzeCSVFields() when closing the import modal 
+  (:issue:`COMPASS-6633`)
+- Optimize CSV field type detection
+
+`Full Changelog: v1.36.1...v1.36.2
+<https://github.com/mongodb-js/compass/compare/v1.36.1...v1.36.2>`__
+
 |compass| 1.36.0
 ----------------
 


### PR DESCRIPTION
## DESCRIPTION

Adds release notes for Compass 1.36.2.

## STAGING

[Release Notes](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-28851-1.36.2-release-notes/release-notes/#compass-1.36.2)

## JIRA

[DOCSP-28851](https://jira.mongodb.org/browse/DOCSP-28851)


## BUILD LOG

[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64514c687efd2382b3428009)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)