### PR TITLE
DOCSP-29494 Add Compass 1.36.4 Release Notes

### DIFF
--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -38,7 +38,6 @@ Bug Fixes:
 `Full Changelog: v1.36.3...v1.36.4
 <https://github.com/mongodb-js/compass/compare/v1.36.3...v1.36.4>`__
 
-
 |compass| 1.36.3
 ----------------
 

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -10,6 +10,35 @@ Release Notes
    :depth: 1
    :class: twocols
 
+|compass| 1.36.4
+----------------
+
+*Released April 27, 2023*
+
+New Features:
+
+- Update add data icon to plus with circle from download (:issue:`COMPASS-6494`)
+- Show import progress in toast, make import background 
+  (:issue:`COMPASS-6540`, :issue:`COMPASS-6555`)
+- Import progress (:issue:`COMPASS-6721`)
+- Update new connection text to new window (:issue:`COMPASS-6723`)
+
+Bug Fixes:
+
+- Remove re-count when not available (:issue:`COMPASS-5179`, :issue:`COMPASS-6649`)
+- Fill autocomplete on tab (:issue:`COMPASS-6695`)
+- Show error border when focused (:issue:`COMPASS-6724`)
+- Compass readonly allows to drop namespaces from the sidebar (:issue:`COMPASS-6687`)
+- Fixes the problem of refresh button on collection tab not refreshing 
+  the collection stats (:issue:`COMPASS-6738`)
+- Update windows config file fetching location one folder up (:issue:`COMPASS-6527`)
+- If listCSVFields() or analyzeCSVFields() fails it will display the error 
+  in the modal (:issue:`COMPASS-6737`)
+
+`Full Changelog: v1.36.3...v1.36.4
+<https://github.com/mongodb-js/compass/compare/v1.36.3...v1.36.4>`__
+
+
 |compass| 1.36.3
 ----------------
 

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -35,7 +35,7 @@ Bug Fixes:
 - If listCSVFields() or analyzeCSVFields() fails it will display the error 
   in the modal (:issue:`COMPASS-6737`)
 
-`Full Changelog: v1.36.3...v1.36.4
+`Full Changelog avaialble on GitHub
 <https://github.com/mongodb-js/compass/compare/v1.36.3...v1.36.4>`__
 
 |compass| 1.36.3
@@ -79,7 +79,7 @@ Bug Fixes:
   (:issue:`COMPASS-6633`)
 - Optimize CSV field type detection
 
-`Full Changelog: v1.36.1...v1.36.2
+`Full Changelog available on GitHub
 <https://github.com/mongodb-js/compass/compare/v1.36.1...v1.36.2>`__
 
 |compass| 1.36.0


### PR DESCRIPTION
## DESCRIPTION

Adds release notes for 1.36.4.

## STAGING

* [Release Notes](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-29494-release-notes-1.36.4/release-notes/#compass-1.36.4)


## JIRA

[DOCSP-29494](https://jira.mongodb.org/browse/DOCSP-29494)

## BUILD LOG

[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64528e597efd2382b387d74b)


## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)