### PR TITLE
DOCSP-29851 Remove Rosetta Install Mentions

### DIFF
--- a/source/install.txt
+++ b/source/install.txt
@@ -26,6 +26,8 @@ Select your operating system:
 
          |compass-short| supports x64 and ARM64 architectures.
 
+         - Apple M1 Silicon is a supported ARM64 architecture and has a separate binary in the download center.
+
      - id: windows
        content: |
 

--- a/source/install.txt
+++ b/source/install.txt
@@ -26,7 +26,7 @@ Select your operating system:
 
          |compass-short| supports x64 and ARM64 architectures.
 
-         - Apple M1 Silicon is a supported ARM64 architecture and has a separate binary in the download center.
+         - M1 Silicon is a supported ARM64 architecture and has a separate binary in the download center.
 
      - id: windows
        content: |

--- a/source/install.txt
+++ b/source/install.txt
@@ -25,25 +25,6 @@ Select your operating system:
          - MongoDB 3.6 or later.
 
          |compass-short| supports x64 and ARM64 architectures.
-         
-         M1 Support
-         ~~~~~~~~~~
-
-         |compass| for macOS can run on M1 platforms that have Rosetta
-         or Rosetta 2 installed.
-         
-         - If you run macOS Big Sur or a more recent operating system,
-           Rosetta (2) is pre-installed and does not require manual
-           installation.
-         
-         - If you run an operating system prior to macOS Big Sur, you
-           must manually `install Rosetta
-           <https://support.apple.com/en-us/HT211861>`__.
-
-         .. note::
-
-            Rosetta is not a MongoDB product. Rosetta is developed and
-            maintained by Apple Inc.
 
      - id: windows
        content: |


### PR DESCRIPTION
## DESCRIPTION

Quick win: removing Rosetta install mentions for the M1 Mac, which is no longer required.

## STAGING

https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-29851/install/

## JIRA

https://jira.mongodb.org/browse/DOCSP-29851

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6463988cdf0f8173e92b33f2

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)