### PR TITLE
DOCSP-30085 Bumping current-version in snooty.toml

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -27,7 +27,7 @@ toc_landing_pages = [
 
 [constants]
 download-page = "`downloads page <https://www.mongodb.com/download-center/compass?tck=docs_compass>`__"
-current-version = "1.35.0"
+current-version = "1.36.4"
 
 [[banners]]
 targets = [


### PR DESCRIPTION
## DESCRIPTION

Updating version in snoty.toml so that the wget commands on the linux installation tab point to the most recent release.

## STAGING

https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-30085/install/

## JIRA

https://jira.mongodb.org/browse/DOCSP-30085

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=646cbb29df0f8173e9f08c2a


## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)