### PR TITLE
DOCSP-30120 Create Re-Direct for Dark Mode Page

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -7,6 +7,6 @@ raw: docs/compass/index.html -> ${base}/current/
 raw: docs/compass/ -> ${base}/current/
 raw: docs/compass/manual/aggregation-pipeline-builder -> ${base}/current/aggregation-pipeline-builder/
 raw: ${base}/current/query/favorite/ -> ${base}/current/query/queries/
-raw: ${base}/current/dark-mode/ -> ${base}/current/settings/settings-reference/#tag/settings
+raw: ${base}/current/dark-mode/ -> ${base}/current/settings/settings-reference/#settings
 
 [master-beta]: docs/compass/${version}/query-bar -> ${base}/${version}/query/filter/

--- a/config/redirects
+++ b/config/redirects
@@ -7,5 +7,6 @@ raw: docs/compass/index.html -> ${base}/current/
 raw: docs/compass/ -> ${base}/current/
 raw: docs/compass/manual/aggregation-pipeline-builder -> ${base}/current/aggregation-pipeline-builder/
 raw: ${base}/current/query/favorite/ -> ${base}/current/query/queries/
+raw: ${base}/current/dark-mode/ -> ${base}/current/settings/settings-reference/#settings
 
 [master-beta]: docs/compass/${version}/query-bar -> ${base}/${version}/query/filter/

--- a/config/redirects
+++ b/config/redirects
@@ -7,6 +7,6 @@ raw: docs/compass/index.html -> ${base}/current/
 raw: docs/compass/ -> ${base}/current/
 raw: docs/compass/manual/aggregation-pipeline-builder -> ${base}/current/aggregation-pipeline-builder/
 raw: ${base}/current/query/favorite/ -> ${base}/current/query/queries/
-raw: ${base}/current/dark-mode/ -> ${base}/current/settings/settings-reference/#settings
+raw: ${base}/current/dark-mode/ -> ${base}/current/settings/settings-reference/#tag/settings
 
 [master-beta]: docs/compass/${version}/query-bar -> ${base}/${version}/query/filter/


### PR DESCRIPTION
## DESCRIPTION
Create re-direct from [deleted dark mode page](https://www.mongodb.com/docs/compass/current/dark-mode/) to [Settings UI page](https://www.mongodb.com/docs/compass/current/settings/settings-reference/).

## STAGING
NOT AVAILABLE FOR REDIRECT

## JIRA
https://jira.mongodb.org/browse/DOCSP-30120

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=646e1bfbdf0f8173e93f28db

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)