### PR TITLE
DOCSP-30779 Config File Reference Redirect

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -8,5 +8,6 @@ raw: docs/compass/ -> ${base}/current/
 raw: docs/compass/manual/aggregation-pipeline-builder -> ${base}/current/aggregation-pipeline-builder/
 raw: docs/compass/current/query/favorite/ -> ${base}/current/query/queries/
 raw: doc/compass/current/dark-mode/ -> ${base}/current/settings/settings-reference/#settings
+raw: doc/compass/current/config-file/config-file-options/ -> ${base}/current/settings/config-file/
 
 [master-beta]: docs/compass/${version}/query-bar -> ${base}/${version}/query/filter/


### PR DESCRIPTION
## DESCRIPTION
Added a redirect for the now-deleted Config File Options page -> redirected to the new config file reference page.

## STAGING
N/A for redirect links

## JIRA
https://jira.mongodb.org/browse/DOCSP-30779

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=648c85ae259a8493e5f9eaac

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)