### PR TITLE
DOCSP-31030 Release Notes for 1.38.1

### DIFF
--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -10,6 +10,7 @@ Release Notes
    :depth: 1
    :class: twocols
 
+
 |compass| 1.39.0
 ----------------
 
@@ -36,6 +37,7 @@ Bug Fixes:
 `Full Changelog available on GitHub
 <https://github.com/mongodb-js/compass/compare/v1.38.2...v1.39.0>`__
 
+
 |compass| 1.38.2
 ----------------
 
@@ -48,6 +50,25 @@ Bug Fix:
 
 `Full Changelog available on GitHub
 <https://github.com/mongodb-js/compass/compare/v1.38.1...v1.38.2>`__
+
+
+|compass| 1.38.1
+----------------
+
+New Features:
+
+- Auto expand object and array field types on field add (:issue:`COMPASS-6939`).
+- Show unindexed query insight in explain plan modal (:issue:`COMPASS-6933`).
+- Show array length on array fields on documents (:issue:`COMPASS-6938`).
+- Add ctrl + tab and ctrl + shift + tab hotkeys for switching tabs.
+- Enable new explain plan by default.
+- Adds insights for usage of $text and $regex in aggregation builder and
+  collection header (:issue:`COMPASS-6834`).
+- Add cues (:issue:`COMPASS-6614`).
+- Signal for bloated documents during import.
+
+`Full Changelog availble on GitHub
+<https://github.com/mongodb-js/compass/compare/v1.38.0...v1.38.1>`__
 
 |compass| 1.38.0
 ----------------


### PR DESCRIPTION
## DESCRIPTION

Release Notes for Compass 1.38.1.

## STAGING

* [RN](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-31030-1.38.1-release-notes/release-notes/#compass-1.38.1)


## JIRA

[DOCSP-31030](https://jira.mongodb.org/browse/DOCSP-31030)

## BUILD LOG
[Build](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=649ef22a423952aeb9fbce80)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)