### PR TITLE
DOCSP-21553 Virtual Desktops Not Supported

### DIFF
--- a/source/install.txt
+++ b/source/install.txt
@@ -6,6 +6,10 @@ Download and Install Compass
 
 .. default-domain:: mongodb
 
+.. important:: 
+
+   |compass| does not support virtual desktop environments.
+
 Select your operating system:
 
 .. _software-reqs:

--- a/source/install.txt
+++ b/source/install.txt
@@ -8,7 +8,7 @@ Download and Install Compass
 
 .. important:: 
 
-   |compass| does not support virtual desktop environments.
+   |compass| doesn't support virtual desktop environments.
 
 Select your operating system:
 


### PR DESCRIPTION
## DESCRIPTION
Adds note to installation page that Compass doesn't support virtual desktop evironments.

## STAGING
https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-21553-virtual-desktops-not-supported/install/#download-and-install-compass

## JIRA
https://jira.mongodb.org/browse/DOCSP-21553

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64af1278423952aeb9bbd954

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)