### PR TITLE
DOCSP-31564 Fix Non-working Redirects

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -7,7 +7,7 @@ raw: docs/compass/index.html -> ${base}/current/
 raw: docs/compass/ -> ${base}/current/
 raw: docs/compass/manual/aggregation-pipeline-builder -> ${base}/current/aggregation-pipeline-builder/
 raw: docs/compass/current/query/favorite/ -> ${base}/current/query/queries/
-raw: doc/compass/current/dark-mode/ -> ${base}/current/settings/settings-reference/#settings
-raw: doc/compass/current/config-file/config-file-options/ -> ${base}/current/settings/config-file/
+raw: docs/compass/current/dark-mode/ -> ${base}/current/settings/settings-reference/#settings
+raw: docs/compass/current/config-file/config-file-options/ -> ${base}/current/settings/config-file/
 
 [master-beta]: docs/compass/${version}/query-bar -> ${base}/${version}/query/filter/


### PR DESCRIPTION
## DESCRIPTION
Fixes typo in redirects.

## STAGING
No staging since these are redirects. Here's the result of running `mut-redirects config/redirects`

`Redirect 301 /docs/compass/current/dark-mode/ https://www.mongodb.com/docs/compass/current/settings/settings-reference/#settings`

`Redirect 301 /docs/compass/current/config-file/config-file-options/ https://www.mongodb.com/docs/compass/current/settings/config-file/`

## JIRA
https://jira.mongodb.org/browse/DOCSP-31564

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64bebd0587b3b360468b7a97

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)