### PR TITLE
DOCSP-32094 Add more query examples

### DIFF
--- a/source/includes/extracts-query-bar.yaml
+++ b/source/includes/extracts-query-bar.yaml
@@ -1,8 +1,8 @@
 ref: query-bar-results
 content: |
-   For query result sets larger than 1000 documents, Compass
-   shows a sampling of the results.  Otherwise, Compass
-   shows the entire result set.
+   For query result sets larger than 1000 documents, Compass shows a
+   subset of the results.  Otherwise, Compass shows the entire result
+   set.
    
    For details on sampling, see :ref:`Sampling <sampling>`.
 ---

--- a/source/query/filter.txt
+++ b/source/query/filter.txt
@@ -101,7 +101,7 @@ sample data into your MongoDB deployment, perform the following steps:
    cluster with sample data. The following example queries filter the
    sample JSON documents provided on this page, and do not work with 
 
-Match Documents on a Single Condition
+Match Documents by a Single Condition
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          
 The following :ref:`query filter <query-bar-filter>` finds
@@ -125,7 +125,7 @@ The query returns the following document:
       "dateCreated": { "$date": "2003-03-26" }
    }
 
-Match Documents on Multiple Conditions
+Match Documents by Multiple Conditions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following query filter finds all documents where ``scores`` array

--- a/source/query/filter.txt
+++ b/source/query/filter.txt
@@ -53,45 +53,52 @@ Examples
 The examples on this page use a small example dataset. To import the
 sample data into your MongoDB deployment, perform the following steps:
 
-1. Copy the following documents to your clipboard:
+.. procedure::
+   :style: normal
 
-   .. code-block:: JSON
+   .. step:: Copy the sample documents
+      
+      Copy the following documents to your clipboard:
 
-      [
-         {
-            "name": "Andrea Le",
-            "email": "andrea_le@fake-mail.com",
-            "version": 5,
-            "scores": [ 85, 95, 75 ],
-            "dateCreated": { "$date": "2003-03-26" }
-         },
-         {
-            "email": "no_name@fake-mail.com",
-            "version": 4,
-            "scores": [ 90, 90, 70 ],
-            "dateCreated": { "$date": "2001-04-15" }
-         },
-         {
-            "name": "Greg Powell",
-            "email": "greg_powell@fake-mail.com",
-            "version": 1,
-            "scores": [ 65, 75, 80 ],
-            "dateCreated": { "$date": "1999-02-10" }
-         }
-      ]
+      .. code-block:: JSON
 
-#. In |compass-short|, use the left navigation panel to select the 
-   database and the collection you want to import the data to.
+         [
+            {
+               "name": "Andrea Le",
+               "email": "andrea_le@fake-mail.com",
+               "version": 5,
+               "scores": [ 85, 95, 75 ],
+               "dateCreated": { "$date": "2003-03-26" }
+            },
+            {
+               "email": "no_name@fake-mail.com",
+               "version": 4,
+               "scores": [ 90, 90, 70 ],
+               "dateCreated": { "$date": "2001-04-15" }
+            },
+            {
+               "name": "Greg Powell",
+               "email": "greg_powell@fake-mail.com",
+               "version": 1,
+               "scores": [ 65, 75, 80 ],
+               "dateCreated": { "$date": "1999-02-10" }
+            }
+         ]
 
-#. Click the :guilabel:`Documents` tab.
+   .. step:: Select your database and collection
+   
+      In |compass-short|, use the left navigation panel to select the 
+      database and the collection you want to import the data to.
 
-#. Click :guilabel:`Add Data` and select :guilabel:`Insert Document`.
+   .. step:: Click the Documents tab.
 
-#. Set the :guilabel:`View` to JSON (``{}``).
+   .. step:: Click :guilabel:`Add Data` and select :guilabel:`Insert Document`.
 
-#. Paste the JSON documents from your clipboard into the modal.
+   .. step:: Set the :guilabel:`View` to JSON (``{}``).
 
-#. Click :guilabel:`Insert`.
+   .. step:: Paste the JSON documents from your clipboard into the modal.
+
+   .. step:: Click :guilabel:`Insert`.
 
 .. note::
 
@@ -177,7 +184,7 @@ The query returns the following documents:
          "_id": { "$oid":"5e349915cebae490877d561e" },
          "email": "no_name@fake-mail.com",
          "version": 4,
-         "scores": [ 90, 90, 75 ],
+         "scores": [ 90, 90, 70 ],
          "dateCreated": { "$date": "2001-04-15" }
       }
    ]
@@ -203,7 +210,7 @@ The query returns the following documents:
          "_id": { "$oid":"5e349915cebae490877d561e" },
          "email": "no_name@fake-mail.com",
          "version": 4,
-         "scores": [ 90, 90, 75 ],
+         "scores": [ 90, 90, 70 ],
          "dateCreated": { "$date": "2001-04-15" }
       },
       {
@@ -242,7 +249,7 @@ The query returns the following documents:
          "_id": { "$oid":"5e349915cebae490877d561e" },
          "email": "no_name@fake-mail.com",
          "version": 4,
-         "scores": [ 90, 90, 75 ],
+         "scores": [ 90, 90, 70 ],
          "dateCreated": { "$date": "2001-04-15" }
       },
       {
@@ -289,7 +296,7 @@ The query returns the following documents:
          "_id": { "$oid": "5e349915cebae490877d561e" },
          "email": "no_name@fake-mail.com",
          "version": 4,
-         "scores": [ 90, 90, 75 ],
+         "scores": [ 90, 90, 70 ],
          "dateCreated": { "$date": "2001-04-15" }
       }
    ]

--- a/source/query/filter.txt
+++ b/source/query/filter.txt
@@ -125,8 +125,8 @@ The query returns the following document:
       "dateCreated": { "$date": "2003-03-26" }
    }
 
-Match Documents by Multiple Conditions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Match Documents by Multiple Conditions ($and)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following query filter finds all documents where ``scores`` array
 contains the value ``75``, and the ``name`` is ``Greg Powell``:
@@ -148,6 +148,39 @@ The query returns the following document:
       "scores": [ 65, 75, 80 ],
       "dateCreated": { "$date": "1999-02-10" }
    }
+
+Match Documents by Multiple Possible Conditions ($or)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following query filter uses the :query:`$or` operator to find
+documents where ``version`` is ``4``, or ``name`` is ``Andrea Le``:
+
+.. code-block:: shell
+
+   { $or: [ { version: 4 }, { name: "Andrea Le" } ] }
+
+The query returns the following documents:
+
+.. code-block:: JSON
+   :copyable: false
+
+   [
+      {
+         "_id": { "$oid": "5e349915cebae490877d561d" },
+         "name": "Andrea Le",
+         "email": "andrea_le@fake-mail.com",
+         "version": 5,
+         "scores": [ 85, 95, 75 ],
+         "dateCreated": { "$date": "2003-03-26" }
+      },
+      {
+         "_id": { "$oid":"5e349915cebae490877d561e" },
+         "email": "no_name@fake-mail.com",
+         "version": 4,
+         "scores": [ 90, 90, 75 ],
+         "dateCreated": { "$date": "2001-04-15" }
+      }
+   ]
 
 Match Documents by Exclusion
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/query/filter.txt
+++ b/source/query/filter.txt
@@ -90,15 +90,15 @@ sample data into your MongoDB deployment, perform the following steps:
       In |compass-short|, use the left navigation panel to select the 
       database and the collection you want to import the data to.
 
-   .. step:: Click the Documents tab.
+   .. step:: Click the Documents tab
 
-   .. step:: Click :guilabel:`Add Data` and select :guilabel:`Insert Document`.
+   .. step:: Click :guilabel:`Add Data` and select :guilabel:`Insert Document`
 
-   .. step:: Set the :guilabel:`View` to JSON (``{}``).
+   .. step:: Set the :guilabel:`View` to JSON (``{}``)
 
-   .. step:: Paste the JSON documents from your clipboard into the modal.
+   .. step:: Paste the JSON documents from your clipboard into the modal
 
-   .. step:: Click :guilabel:`Insert`.
+   .. step:: Click :guilabel:`Insert`
 
 .. note::
 

--- a/source/query/filter.txt
+++ b/source/query/filter.txt
@@ -59,24 +59,24 @@ sample data to your MongoDB deployment, perform the following steps:
 
       [
          {
-            "name":"Andrea Le",
-            "email":"andrea_le@fakegmail.com",
-            "version":5,
-            "scores":[85, 95, 75],
-            "dateCreated":{"$date":"2003-03-26"}
+            "name": "Andrea Le",
+            "email": "andrea_le@fakegmail.com",
+            "version": 5,
+            "scores": [ 85, 95, 75 ],
+            "dateCreated": { "$date": "2003-03-26" }
          },
          {
-            "email":"no_name@fakegmail.com",
-            "version":4,
-            "scores":[90, 90, 70],
-            "dateCreated":{"$date":"2001-04-15"}
+            "email": "no_name@fakegmail.com",
+            "version": 4,
+            "scores": [ 90, 90, 70 ],
+            "dateCreated": { "$date": "2001-04-15" }
          },
          {
-            "name":"Greg Powell",
-            "email":"greg_powell@fakegmail.com",
-            "version":1,
-            "scores":[65, 75, 80],
-            "dateCreated":{"$date":"1999-02-10"}
+            "name": "Greg Powell",
+            "email": "greg_powell@fakegmail.com",
+            "version": 1,
+            "scores": [ 65, 75, 80 ],
+            "dateCreated": { "$date": "1999-02-10" }
          }
       ]
 
@@ -87,8 +87,9 @@ sample data to your MongoDB deployment, perform the following steps:
 
 #. Click :guilabel:`Add Data` and select :guilabel:`Insert Document`.
 
-#. Set the :guilabel:`View` is set to JSON, or ``{}``, and paste the
-   copied JSON documents in the field.
+#. Set the :guilabel:`View` is set to JSON (``{}``)
+
+#. Paste the JSON documents from your clipboard into the modal.
 
 #. Click :guilabel:`Insert`.
 
@@ -116,16 +117,37 @@ The query returns the following document:
    :copyable: false
 
    {
-      "_id": {"$oid": "5e349915cebae490877d561d"},
-      "name":"Andrea Le",
-      "email":"andrea_le@fakegmail.com",
-      "version":5,
-      "scores":[85, 95, 75],
-      "dateCreated":{"$date":"2003-03-26"}
+      "_id": { "$oid": "5e349915cebae490877d561d" },
+      "name": "Andrea Le",
+      "email": "andrea_le@fakegmail.com",
+      "version": 5,
+      "scores": [ 85, 95, 75 ],
+      "dateCreated": { "$date": "2003-03-26" }
    }
 
 Match Documents on Multiple Conditions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following query filter finds all documents where ``scores`` array
+contains the value ``75``, and the ``name`` is ``Greg Powell``:
+
+.. code-block:: shell
+
+   { scores: 75, name: "Greg Powell" }
+
+The query returns the following document:
+
+.. code-block:: JSON
+   :copyable: false
+
+   {
+      "_id": { "$oid":"5a9427648b0beebeb69579cf" },
+      "name": "Greg Powell",
+      "email": "greg_powell@fakegmail.com",
+      "version": 1,
+      "scores": [ 65, 75, 80 ],
+      "dateCreated": { "$date": "1999-02-10" }
+   }
 
 Match Documents by Exclusion
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -145,26 +167,26 @@ The query returns the following documents:
 
    [
       {
-         "_id":{"$oid":"5e349915cebae490877d561e"},
-         "email":"no_name@fakegmail.com",
-         "version":4,
-         "scores":[90, 90, 75],
-         "dateCreated":{"$date":"2001-04-15"}
+         "_id": { "$oid":"5e349915cebae490877d561e" },
+         "email": "no_name@fakegmail.com",
+         "version": 4,
+         "scores": [ 90, 90, 75 ],
+         "dateCreated": { "$date": "2001-04-15" }
       },
       {
-         "_id":{"$oid":"5a9427648b0beebeb69579cf"},
-         "name":"Greg Powell",
-         "email":"greg_powell@fakegmail.com",
-         "version":1,
-         "scores":[65, 75, 80],
-         "dateCreated":{"$date":"1999-02-10"}
+         "_id": { "$oid":"5a9427648b0beebeb69579cf" },
+         "name": "Greg Powell",
+         "email": "greg_powell@fakegmail.com",
+         "version": 1,
+         "scores": [ 65, 75, 80 ],
+         "dateCreated": { "$date": "1999-02-10" }
       }
    ]
 
-      .. seealso::
+.. seealso::
 
-         For a complete list of logical query operators, see 
-         :manual:`Logical Query Operators</reference/operator/query-logical/>`.
+   For a complete list of logical query operators, see 
+   :manual:`Logical Query Operators</reference/operator/query-logical/>`.
 
 
 Match Documents with Comparison Operators
@@ -184,19 +206,19 @@ The query returns the following documents:
 
    [
       {
-         "_id":{"$oid":"5e349915cebae490877d561e"},
-         "email":"no_name@fakegmail.com",
-         "version":4,
-         "scores":[90, 90, 75],
-         "dateCreated":{"$date":"2001-04-15"}
+         "_id": { "$oid":"5e349915cebae490877d561e" },
+         "email": "no_name@fakegmail.com",
+         "version": 4,
+         "scores": [ 90, 90, 75 ],
+         "dateCreated": { "$date": "2001-04-15" }
       },
       {
-         "_id":{"$oid":"5a9427648b0beebeb69579cf"},
-         "name":"Greg Powell",
-         "email":"greg_powell@fakegmail.com",
-         "version":1,
-         "scores":[65, 75, 80],
-         "dateCreated":{"$date":"1999-02-10"}
+         "_id": { "$oid":"5a9427648b0beebeb69579cf" },
+         "name": "Greg Powell",
+         "email": "greg_powell@fakegmail.com",
+         "version": 1,
+         "scores": [ 65, 75, 80 ],
+         "dateCreated": { "$date": "1999-02-10" }
       }
    ]
 
@@ -224,19 +246,19 @@ the ``dateCreated`` field values are after June 22, 2000.
 
    [
       {
-         "_id": {"$oid": "5e349915cebae490877d561d"},
-         "name":"Andrea Le",
-         "email":"andrea_le@fakegmail.com",
-         "version":5,
-         "scores":[85, 95, 75],
-         "dateCreated":{"$date":"2003-03-26"}
+         "_id": { "$oid": "5e349915cebae490877d561d" },
+         "name": "Andrea Le",
+         "email": "andrea_le@fakegmail.com",
+         "version": 5,
+         "scores": [ 85, 95, 75 ],
+         "dateCreated": { "$date": "2003-03-26" }
       },
       {
-         "_id":{"$oid":"5e349915cebae490877d561e"},
-         "email":"no_name@fakegmail.com",
-         "version":4,
-         "scores":[90, 90, 75],
-         "dateCreated":{"$date":"2001-04-15"}
+         "_id": { "$oid": "5e349915cebae490877d561e" },
+         "email": "no_name@fakegmail.com",
+         "version": 4,
+         "scores": [ 90, 90, 75 ],
+         "dateCreated": { "$date": "2001-04-15" }
       }
    ]
          
@@ -258,12 +280,12 @@ in the ``scores`` array is ``85``:
    :copyable: false
 
    {
-      "_id": {"$oid": "5e349915cebae490877d561d"},
-      "name":"Andrea Le",
-      "email":"andrea_le@fakegmail.com",
-      "version":5,
-      "scores":[85, 95, 75],
-      "dateCreated":{"$date":"2003-03-26"}
+      "_id": { "$oid": "5e349915cebae490877d561d" },
+      "name": "Andrea Le",
+      "email": "andrea_le@fakegmail.com",
+      "version": 5,
+      "scores": [ 85, 95, 75 ],
+      "dateCreated": { "$date": "2003-03-26" }
    }
    
 Match Documents by UUID
@@ -283,12 +305,12 @@ The query returns the following document:
 
    {
       "_id": UUID('002636e1-10cd-4c8b-a9a7-01b7bfd3899c'),
-      "name":"Mr. Florencio Breitenberg",
-      "email":"Florencio.Breitenberg",
-      "phone":"876.349.6791 x616"
-      "website":"nelle.name",
+      "name": "Mr. Florencio Breitenberg",
+      "email": "Florencio.Breitenberg",
+      "phone": "876.349.6791 x616"
+      "website": "nelle.name",
       "country": "Zimbabwe",
-      "age":31
+      "age": 31
    }
 
 For more query examples, see 

--- a/source/query/filter.txt
+++ b/source/query/filter.txt
@@ -11,7 +11,7 @@ Query Your Data
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 1
+   :depth: 2
    :class: singlecol
 
 You can type MongoDB filter documents into the query bar to display only
@@ -46,6 +46,254 @@ Set Query Filter
 .. note::
 
    .. include:: /includes/extracts/query-bar-results.rst
+
+Examples
+--------
+
+The examples on this page use a small example dataset. To import the
+sample data to your MongoDB deployment, perform the following steps:
+
+1. Copy the following documents to your clipboard:
+
+   .. code-block:: JSON
+
+      [
+         {
+            "name":"Andrea Le",
+            "email":"andrea_le@fakegmail.com",
+            "version":5,
+            "scores":[85, 95, 75],
+            "dateCreated":{"$date":"2003-03-26"}
+         },
+         {
+            "email":"no_name@fakegmail.com",
+            "version":4,
+            "scores":[90, 90, 70],
+            "dateCreated":{"$date":"2001-04-15"}
+         },
+         {
+            "name":"Greg Powell",
+            "email":"greg_powell@fakegmail.com",
+            "version":1,
+            "scores":[65, 75, 80],
+            "dateCreated":{"$date":"1999-02-10"}
+         }
+      ]
+
+#. In |compass-short|, use the left navigation panel to select the 
+   database and the collection you want to import the data to.
+
+#. Click the :guilabel:`Documents` tab.
+
+#. Click :guilabel:`Add Data` and select :guilabel:`Insert Document`.
+
+#. Set the :guilabel:`View` is set to JSON, or ``{}``, and paste the
+   copied JSON documents in the field.
+
+#. Click :guilabel:`Insert`.
+
+.. note::
+
+   If you do not have a MongoDB deployment or if you want to query a
+   larger sample data set, see :atlas:`Sample Data for Atlas
+   Clusters </sample-data/>` for instructions on creating a free-tier
+   cluster with sample data. The following example queries filter the
+   sample JSON documents provided on this page, and do not work with 
+
+Match Documents on a Single Condition
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         
+The following :ref:`query filter <query-bar-filter>` finds
+all documents where the value of ``name`` is "Andrea Le":
+
+.. code-block:: shell
+
+   { name: "Andrea Le" }
+
+The query returns the following document:
+
+.. code-block:: JSON
+   :copyable: false
+
+   {
+      "_id": {"$oid": "5e349915cebae490877d561d"},
+      "name":"Andrea Le",
+      "email":"andrea_le@fakegmail.com",
+      "version":5,
+      "scores":[85, 95, 75],
+      "dateCreated":{"$date":"2003-03-26"}
+   }
+
+Match Documents on Multiple Conditions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Match Documents by Exclusion
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         
+The following query filter uses the :query:`$not` operator to find all
+documents where the value of the ``name`` field is **not** equal to
+"Andrea Le", or the ``name`` field does not exist:
+
+.. code-block:: shell
+
+   { name: { $not: { $eq: "Andrea Le" } } }
+
+The query returns the following documents:
+
+.. code-block:: JSON
+   :copyable: false
+
+   [
+      {
+         "_id":{"$oid":"5e349915cebae490877d561e"},
+         "email":"no_name@fakegmail.com",
+         "version":4,
+         "scores":[90, 90, 75],
+         "dateCreated":{"$date":"2001-04-15"}
+      },
+      {
+         "_id":{"$oid":"5a9427648b0beebeb69579cf"},
+         "name":"Greg Powell",
+         "email":"greg_powell@fakegmail.com",
+         "version":1,
+         "scores":[65, 75, 80],
+         "dateCreated":{"$date":"1999-02-10"}
+      }
+   ]
+
+      .. seealso::
+
+         For a complete list of logical query operators, see 
+         :manual:`Logical Query Operators</reference/operator/query-logical/>`.
+
+
+Match Documents with Comparison Operators
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         
+The following query filter uses the :query:`$lte` operator to find all
+documents where ``version`` is less than or equal to ``4``:
+
+.. code-block:: shell
+
+   { version: { $lte: 4 } }
+
+The query returns the following documents:
+
+.. code-block:: JSON
+   :copyable: false
+
+   [
+      {
+         "_id":{"$oid":"5e349915cebae490877d561e"},
+         "email":"no_name@fakegmail.com",
+         "version":4,
+         "scores":[90, 90, 75],
+         "dateCreated":{"$date":"2001-04-15"}
+      },
+      {
+         "_id":{"$oid":"5a9427648b0beebeb69579cf"},
+         "name":"Greg Powell",
+         "email":"greg_powell@fakegmail.com",
+         "version":1,
+         "scores":[65, 75, 80],
+         "dateCreated":{"$date":"1999-02-10"}
+      }
+   ]
+
+.. seealso::
+
+   For a complete list of comparison operators, see 
+   :manual:`Comparison Query Operators </reference/operator/query-comparison/>`.
+
+Match Documents by Date
+~~~~~~~~~~~~~~~~~~~~~~~
+         
+The following query filter uses the :query:`$gt` operator and
+:method:`Date()` method to find all documents where the ``dateCreated``
+field value is later than June 22nd, 2000:
+
+.. code-block:: shell
+
+   { dateCreated: { $gt: Date('2000-06-22') } }
+
+The query returns the following documents because 
+the ``dateCreated`` field values are after June 22, 2000.
+
+.. code-block:: JSON
+   :copyable: false
+
+   [
+      {
+         "_id": {"$oid": "5e349915cebae490877d561d"},
+         "name":"Andrea Le",
+         "email":"andrea_le@fakegmail.com",
+         "version":5,
+         "scores":[85, 95, 75],
+         "dateCreated":{"$date":"2003-03-26"}
+      },
+      {
+         "_id":{"$oid":"5e349915cebae490877d561e"},
+         "email":"no_name@fakegmail.com",
+         "version":4,
+         "scores":[90, 90, 75],
+         "dateCreated":{"$date":"2001-04-15"}
+      }
+   ]
+         
+Match Documents by Array Conditions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+         
+The following query filter uses the :query:`$elemMatch` operator
+to find all documents where at least one value in the ``scores``
+array is greater than 80 and less than ``90``:
+
+.. code-block:: shell
+
+   { scores: { $elemMatch: { $gt: 80, $lt: 90 } } }
+
+The query returns the following document because one of the values
+in the ``scores`` array is ``85``:
+
+.. code-block:: JSON
+   :copyable: false
+
+   {
+      "_id": {"$oid": "5e349915cebae490877d561d"},
+      "name":"Andrea Le",
+      "email":"andrea_le@fakegmail.com",
+      "version":5,
+      "scores":[85, 95, 75],
+      "dateCreated":{"$date":"2003-03-26"}
+   }
+   
+Match Documents by UUID
+~~~~~~~~~~~~~~~~~~~~~~~
+            
+The following query filter finds documents where the UUID is
+"002636e1-10cd-4c8b-a9a7-01b7bfd3899c". 
+
+.. code-block:: shell
+
+   {_id: UUID('002636e1-10cd-4c8b-a9a7-01b7bfd3899c')}
+
+The query returns the following document:
+
+.. code-block:: JSON
+   :copyable: false
+
+   {
+      "_id": UUID('002636e1-10cd-4c8b-a9a7-01b7bfd3899c'),
+      "name":"Mr. Florencio Breitenberg",
+      "email":"Florencio.Breitenberg",
+      "phone":"876.349.6791 x616"
+      "website":"nelle.name",
+      "country": "Zimbabwe",
+      "age":31
+   }
+
+For more query examples, see 
+:manual:`Query Documents </tutorial/query-documents/>` 
+in the MongoDB manual.
 
 Supported Data Types in the Query Bar
 -------------------------------------
@@ -108,273 +356,6 @@ How Does the Compass Query Compare to MongoDB and SQL Queries?
 
          SELECT * FROM article
          WHERE author = "Joe Bloggs";
-
-Examples
---------
-
-.. example::
-
-   The following examples use the JSON documents below as sample data. 
-   To import this sample data to your MongoDB deployment with |compass|:
-
-   1. Copy the array of documents below by clicking :guilabel:`Copy`.
-
-   .. code-block:: JSON
-
-      [
-         {
-            "name":"Andrea Le",
-            "email":"andrea_le@fakegmail.com",
-            "version":5,
-            "scores":[85, 95, 75],
-            "dateCreated":{"$date":"2003-03-26"}
-         },
-         {
-            "email":"no_name@fakegmail.com",
-            "version":4,
-            "scores":[90, 90, 70],
-            "dateCreated":{"$date":"2001-04-15"}
-         },
-         {
-            "name":"Greg Powell",
-            "email":"greg_powell@fakegmail.com",
-            "version":1,
-            "scores":[65, 75, 80],
-            "dateCreated":{"$date":"1999-02-10"}
-         }
-      ]
-
-   2. In |compass-short|, use the left navigation panel to select the 
-      database and the collection you want to import the data to.
-   
-   #. Click the :guilabel:`Documents` tab.
-   
-   #. Click :guilabel:`Add Data` and select :guilabel:`Insert Document`.
-
-   #. Ensure that :guilabel:`View` is set to JSON, or ``{}``, and paste 
-      the copied JSON documents in the field.
-
-   #. Click :guilabel:`Insert`.
-
-.. note::
-
-   If you do not have a MongoDB deployment or if you would like to 
-   query a large sample data set, see
-   :atlas:`Sample Data for Atlas Clusters</sample-data/>` for 
-   instructions on creating a free-tier cluster with sample data. Note 
-   that the examples below are intended to filter the sample JSON 
-   documents provided on this page and may not properly filter another 
-   sample data set.
-
-.. tabs::
-
-   .. tab:: Match
-      :tabid: match
-         
-      The following :ref:`query filter <query-bar-filter>` finds
-      all documents where the value of ``name`` is "Andrea Le".
-
-      .. code-block:: shell
-
-         { name: "Andrea Le" }
-
-      The query returns the following document because the ``name`` 
-      field value is an exact match.
-
-      .. code-block:: JSON
-         :copyable: false
-
-         {
-            "_id": {"$oid": "5e349915cebae490877d561d"},
-            "name":"Andrea Le",
-            "email":"andrea_le@fakegmail.com",
-            "version":5,
-            "scores":[85, 95, 75],
-            "dateCreated":{"$date":"2003-03-26"}
-         }
-
-   .. tab:: Exclusion ($not)
-      :tabid: not
-         
-      The following :ref:`query filter <query-bar-filter>` uses the 
-      :manual:`$not operator </reference/operator/query/not/>` to find 
-      all documents where:
-      
-      - The value of the ``name`` field is **not** equal to "Andrea Le",
-        or
-
-      - The ``name`` field does not exist
-
-      .. code-block:: shell
-
-         { name: { $not: { $eq: "Andrea Le" } } }
-
-      The query returns the following documents because the ``name`` 
-      field either does not exist or its value is something other than 
-      "Andrea Le".
-
-      .. code-block:: JSON
-         :copyable: false
-
-         [
-            {
-               "_id":{"$oid":"5e349915cebae490877d561e"},
-               "email":"no_name@fakegmail.com",
-               "version":4,
-               "scores":[90, 90, 75],
-               "dateCreated":{"$date":"2001-04-15"}
-            },
-            {
-               "_id":{"$oid":"5a9427648b0beebeb69579cf"},
-               "name":"Greg Powell",
-               "email":"greg_powell@fakegmail.com",
-               "version":1,
-               "scores":[65, 75, 80],
-               "dateCreated":{"$date":"1999-02-10"}
-            }
-         ]
-
-      .. seealso::
-
-         For a complete list of logical query operators, see 
-         :manual:`Logical Query Operators</reference/operator/query-logical/>`.
-
-   .. tab:: Comparison
-      :tabid: compare
-         
-      The following :ref:`query filter <query-bar-filter>` uses the 
-      :manual:`$lte operator </reference/operator/query/lte/>` to 
-      find all documents where ``version`` is less than or equal 
-      to ``4``.
-
-      .. code-block:: shell
-
-         { version: { $lte: 4 } }
-
-      The query returns the following documents because 
-      the ``version`` field values are less than or equal to ``4``.
-
-      .. code-block:: JSON
-         :copyable: false
-
-         [
-            {
-               "_id":{"$oid":"5e349915cebae490877d561e"},
-               "email":"no_name@fakegmail.com",
-               "version":4,
-               "scores":[90, 90, 75],
-               "dateCreated":{"$date":"2001-04-15"}
-            },
-            {
-               "_id":{"$oid":"5a9427648b0beebeb69579cf"},
-               "name":"Greg Powell",
-               "email":"greg_powell@fakegmail.com",
-               "version":1,
-               "scores":[65, 75, 80],
-               "dateCreated":{"$date":"1999-02-10"}
-            }
-         ]
-
-      .. seealso::
-
-         For a complete list of comparison operators, see 
-         :manual:`Comparison Query Operators </reference/operator/query-comparison/>`.
-
-   .. tab:: Date
-      :tabid: date
-         
-      The following :ref:`query filter <query-bar-filter>` uses the 
-      :manual:`$gt operator </reference/operator/query/gt/>` and 
-      :manual:`Date() method </reference/method/Date/>` to find all 
-      documents where the ``dateCreated`` field value is later than 
-      June 22nd, 2000.
-
-      .. code-block:: shell
-
-         { dateCreated: { $gt: Date('2000-06-22') } }
-
-      The query returns the following documents because 
-      the ``dateCreated`` field values are after June 22, 2000.
-
-      .. code-block:: JSON
-         :copyable: false
-
-         [
-            {
-               "_id": {"$oid": "5e349915cebae490877d561d"},
-               "name":"Andrea Le",
-               "email":"andrea_le@fakegmail.com",
-               "version":5,
-               "scores":[85, 95, 75],
-               "dateCreated":{"$date":"2003-03-26"}
-            },
-            {
-               "_id":{"$oid":"5e349915cebae490877d561e"},
-               "email":"no_name@fakegmail.com",
-               "version":4,
-               "scores":[90, 90, 75],
-               "dateCreated":{"$date":"2001-04-15"}
-            }
-         ]
-         
-
-   .. tab:: Array
-      :tabid: array
-         
-      The following :ref:`query filter <query-bar-filter>` uses the
-      :manual:`$elemMatch operator </reference/operator/query/elemMatch/>` to find all documents where at least one value in 
-      the ``scores`` array is greater than 80 and less than ``90`` 
-
-      .. code-block:: shell
-
-         { scores: { $elemMatch: { $gt: 80, $lt: 90 } } }
-
-      The query returns the following document because one of the 
-      values in the scores array is ``85``, which matches the 
-      ``$elemMatch`` criteria.
-
-      .. code-block:: JSON
-         :copyable: false
-
-         {
-            "_id": {"$oid": "5e349915cebae490877d561d"},
-            "name":"Andrea Le",
-            "email":"andrea_le@fakegmail.com",
-            "version":5,
-            "scores":[85, 95, 75],
-            "dateCreated":{"$date":"2003-03-26"}
-         }
-   
-   .. tab:: UUID
-      :tabid: uuid
-            
-      The following :ref:`query filter <query-bar-filter>` finds
-      all documents where the UUID is 
-      "002636e1-10cd-4c8b-a9a7-01b7bfd3899c". 
-   
-      .. code-block:: shell
-   
-         {_id: UUID('002636e1-10cd-4c8b-a9a7-01b7bfd3899c')}
-   
-      The query returns the following document because the ``UUID`` 
-      is an exact match.
-   
-      .. code-block:: JSON
-         :copyable: false
-   
-         {
-            "_id": UUID('002636e1-10cd-4c8b-a9a7-01b7bfd3899c'),
-            "name":"Mr. Florencio Breitenberg",
-            "email":"Florencio.Breitenberg",
-            "phone":"876.349.6791 x616"
-            "website":"nelle.name",
-            "country": "Zimbabwe",
-            "age":31
-         }
-
-For more query examples, see 
-:manual:`Query Documents </tutorial/query-documents/>` 
-in the MongoDB manual.
 
 .. toctree::
    :titlesonly:

--- a/source/query/filter.txt
+++ b/source/query/filter.txt
@@ -96,10 +96,10 @@ sample data into your MongoDB deployment, perform the following steps:
 .. note::
 
    If you do not have a MongoDB deployment or if you want to query a
-   larger sample data set, see :atlas:`Sample Data for Atlas
-   Clusters </sample-data/>` for instructions on creating a free-tier
-   cluster with sample data. The following example queries filter the
-   sample JSON documents provided on this page, and do not work with 
+   larger sample data set, see :atlas:`Sample Data for Atlas Clusters
+   </sample-data/>` for instructions on creating a free-tier cluster
+   with sample data. The following example queries filter the sample
+   documents provided on this page.
 
 Match Documents by a Single Condition
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/query/filter.txt
+++ b/source/query/filter.txt
@@ -53,52 +53,45 @@ Examples
 The examples on this page use a small example dataset. To import the
 sample data into your MongoDB deployment, perform the following steps:
 
-.. procedure::
-   :style: normal
+1. Copy the following documents to your clipboard:
 
-   .. step:: Copy the sample documents
-      
-      Copy the following documents to your clipboard:
+   .. code-block:: JSON
 
-      .. code-block:: JSON
+      [
+         {
+            "name": "Andrea Le",
+            "email": "andrea_le@fake-mail.com",
+            "version": 5,
+            "scores": [ 85, 95, 75 ],
+            "dateCreated": { "$date": "2003-03-26" }
+         },
+         {
+            "email": "no_name@fake-mail.com",
+            "version": 4,
+            "scores": [ 90, 90, 70 ],
+            "dateCreated": { "$date": "2001-04-15" }
+         },
+         {
+            "name": "Greg Powell",
+            "email": "greg_powell@fake-mail.com",
+            "version": 1,
+            "scores": [ 65, 75, 80 ],
+            "dateCreated": { "$date": "1999-02-10" }
+         }
+      ]
 
-         [
-            {
-               "name": "Andrea Le",
-               "email": "andrea_le@fake-mail.com",
-               "version": 5,
-               "scores": [ 85, 95, 75 ],
-               "dateCreated": { "$date": "2003-03-26" }
-            },
-            {
-               "email": "no_name@fake-mail.com",
-               "version": 4,
-               "scores": [ 90, 90, 70 ],
-               "dateCreated": { "$date": "2001-04-15" }
-            },
-            {
-               "name": "Greg Powell",
-               "email": "greg_powell@fake-mail.com",
-               "version": 1,
-               "scores": [ 65, 75, 80 ],
-               "dateCreated": { "$date": "1999-02-10" }
-            }
-         ]
+#. In |compass-short|, use the left navigation panel to select the 
+   database and the collection you want to import the data to.
 
-   .. step:: Select your database and collection
-   
-      In |compass-short|, use the left navigation panel to select the 
-      database and the collection you want to import the data to.
+#. Click the :guilabel:`Documents` tab.
 
-   .. step:: Click the Documents tab
+#. Click :guilabel:`Add Data` and select :guilabel:`Insert Document`.
 
-   .. step:: Click :guilabel:`Add Data` and select :guilabel:`Insert Document`
+#. Set the :guilabel:`View` to JSON (``{}``).
 
-   .. step:: Set the :guilabel:`View` to JSON (``{}``)
+#. Paste the JSON documents from your clipboard into the modal.
 
-   .. step:: Paste the JSON documents from your clipboard into the modal
-
-   .. step:: Click :guilabel:`Insert`
+#. Click :guilabel:`Insert`.
 
 .. note::
 

--- a/source/query/filter.txt
+++ b/source/query/filter.txt
@@ -51,7 +51,7 @@ Examples
 --------
 
 The examples on this page use a small example dataset. To import the
-sample data to your MongoDB deployment, perform the following steps:
+sample data into your MongoDB deployment, perform the following steps:
 
 1. Copy the following documents to your clipboard:
 
@@ -87,7 +87,7 @@ sample data to your MongoDB deployment, perform the following steps:
 
 #. Click :guilabel:`Add Data` and select :guilabel:`Insert Document`.
 
-#. Set the :guilabel:`View` is set to JSON (``{}``)
+#. Set the :guilabel:`View` to JSON (``{}``).
 
 #. Paste the JSON documents from your clipboard into the modal.
 

--- a/source/query/filter.txt
+++ b/source/query/filter.txt
@@ -101,8 +101,8 @@ sample data into your MongoDB deployment, perform the following steps:
    with sample data. The following example queries filter the sample
    documents provided on this page.
 
-Match Documents by a Single Condition
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Match by a Single Condition
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
          
 The following query filter finds all documents where the value of
 ``name`` is "Andrea Le":
@@ -125,8 +125,8 @@ The query returns the following document:
       "dateCreated": { "$date": "2003-03-26" }
    }
 
-Match Documents by Multiple Conditions ($and)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Match by Multiple Conditions ($and)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following query filter finds all documents where ``scores`` array
 contains the value ``75``, and the ``name`` is ``Greg Powell``:
@@ -149,8 +149,8 @@ The query returns the following document:
       "dateCreated": { "$date": "1999-02-10" }
    }
 
-Match Documents by Multiple Possible Conditions ($or)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Match by Multiple Possible Conditions ($or)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following query filter uses the :query:`$or` operator to find
 documents where ``version`` is ``4``, or ``name`` is ``Andrea Le``:
@@ -182,8 +182,8 @@ The query returns the following documents:
       }
    ]
 
-Match Documents by Exclusion
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Match by Exclusion ($not)
+~~~~~~~~~~~~~~~~~~~~~~~~~
          
 The following query filter uses the :query:`$not` operator to find all
 documents where the value of the ``name`` field is **not** equal to
@@ -222,8 +222,8 @@ The query returns the following documents:
    :manual:`Logical Query Operators</reference/operator/query-logical/>`.
 
 
-Match Documents with Comparison Operators
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Match with Comparison Operators
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          
 The following query filter uses the :query:`$lte` operator to find all
 documents where ``version`` is less than or equal to ``4``:
@@ -260,8 +260,8 @@ The query returns the following documents:
    For a complete list of comparison operators, see 
    :manual:`Comparison Query Operators </reference/operator/query-comparison/>`.
 
-Match Documents by Date
-~~~~~~~~~~~~~~~~~~~~~~~
+Match by Date
+~~~~~~~~~~~~~
          
 The following query filter uses the :query:`$gt` operator and
 :method:`Date()` method to find all documents where the ``dateCreated``
@@ -295,8 +295,8 @@ the ``dateCreated`` field values are after June 22, 2000.
       }
    ]
          
-Match Documents by Array Conditions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Match by Array Conditions
+~~~~~~~~~~~~~~~~~~~~~~~~~
          
 The following query filter uses the :query:`$elemMatch` operator
 to find all documents where at least one value in the ``scores``

--- a/source/query/filter.txt
+++ b/source/query/filter.txt
@@ -104,8 +104,8 @@ sample data into your MongoDB deployment, perform the following steps:
 Match Documents by a Single Condition
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
          
-The following :ref:`query filter <query-bar-filter>` finds
-all documents where the value of ``name`` is "Andrea Le":
+The following query filter finds all documents where the value of
+``name`` is "Andrea Le":
 
 .. code-block:: shell
 

--- a/source/query/filter.txt
+++ b/source/query/filter.txt
@@ -29,8 +29,8 @@ Set Query Filter
 
    .. example::
 
-      The following filter only returns documents which have a ``title``
-      value of ``Jurassic Park``:
+      The following filter returns documents that have a ``title`` value
+      of ``Jurassic Park``:
       
       .. code-block:: json
       
@@ -60,20 +60,20 @@ sample data to your MongoDB deployment, perform the following steps:
       [
          {
             "name": "Andrea Le",
-            "email": "andrea_le@fakegmail.com",
+            "email": "andrea_le@fake-mail.com",
             "version": 5,
             "scores": [ 85, 95, 75 ],
             "dateCreated": { "$date": "2003-03-26" }
          },
          {
-            "email": "no_name@fakegmail.com",
+            "email": "no_name@fake-mail.com",
             "version": 4,
             "scores": [ 90, 90, 70 ],
             "dateCreated": { "$date": "2001-04-15" }
          },
          {
             "name": "Greg Powell",
-            "email": "greg_powell@fakegmail.com",
+            "email": "greg_powell@fake-mail.com",
             "version": 1,
             "scores": [ 65, 75, 80 ],
             "dateCreated": { "$date": "1999-02-10" }
@@ -119,7 +119,7 @@ The query returns the following document:
    {
       "_id": { "$oid": "5e349915cebae490877d561d" },
       "name": "Andrea Le",
-      "email": "andrea_le@fakegmail.com",
+      "email": "andrea_le@fake-mail.com",
       "version": 5,
       "scores": [ 85, 95, 75 ],
       "dateCreated": { "$date": "2003-03-26" }
@@ -143,7 +143,7 @@ The query returns the following document:
    {
       "_id": { "$oid":"5a9427648b0beebeb69579cf" },
       "name": "Greg Powell",
-      "email": "greg_powell@fakegmail.com",
+      "email": "greg_powell@fake-mail.com",
       "version": 1,
       "scores": [ 65, 75, 80 ],
       "dateCreated": { "$date": "1999-02-10" }
@@ -168,7 +168,7 @@ The query returns the following documents:
    [
       {
          "_id": { "$oid":"5e349915cebae490877d561e" },
-         "email": "no_name@fakegmail.com",
+         "email": "no_name@fake-mail.com",
          "version": 4,
          "scores": [ 90, 90, 75 ],
          "dateCreated": { "$date": "2001-04-15" }
@@ -176,7 +176,7 @@ The query returns the following documents:
       {
          "_id": { "$oid":"5a9427648b0beebeb69579cf" },
          "name": "Greg Powell",
-         "email": "greg_powell@fakegmail.com",
+         "email": "greg_powell@fake-mail.com",
          "version": 1,
          "scores": [ 65, 75, 80 ],
          "dateCreated": { "$date": "1999-02-10" }
@@ -207,7 +207,7 @@ The query returns the following documents:
    [
       {
          "_id": { "$oid":"5e349915cebae490877d561e" },
-         "email": "no_name@fakegmail.com",
+         "email": "no_name@fake-mail.com",
          "version": 4,
          "scores": [ 90, 90, 75 ],
          "dateCreated": { "$date": "2001-04-15" }
@@ -215,7 +215,7 @@ The query returns the following documents:
       {
          "_id": { "$oid":"5a9427648b0beebeb69579cf" },
          "name": "Greg Powell",
-         "email": "greg_powell@fakegmail.com",
+         "email": "greg_powell@fake-mail.com",
          "version": 1,
          "scores": [ 65, 75, 80 ],
          "dateCreated": { "$date": "1999-02-10" }
@@ -248,14 +248,14 @@ the ``dateCreated`` field values are after June 22, 2000.
       {
          "_id": { "$oid": "5e349915cebae490877d561d" },
          "name": "Andrea Le",
-         "email": "andrea_le@fakegmail.com",
+         "email": "andrea_le@fake-mail.com",
          "version": 5,
          "scores": [ 85, 95, 75 ],
          "dateCreated": { "$date": "2003-03-26" }
       },
       {
          "_id": { "$oid": "5e349915cebae490877d561e" },
-         "email": "no_name@fakegmail.com",
+         "email": "no_name@fake-mail.com",
          "version": 4,
          "scores": [ 90, 90, 75 ],
          "dateCreated": { "$date": "2001-04-15" }
@@ -267,7 +267,7 @@ Match Documents by Array Conditions
          
 The following query filter uses the :query:`$elemMatch` operator
 to find all documents where at least one value in the ``scores``
-array is greater than 80 and less than ``90``:
+array is greater than ``80`` and less than ``90``:
 
 .. code-block:: shell
 
@@ -282,35 +282,10 @@ in the ``scores`` array is ``85``:
    {
       "_id": { "$oid": "5e349915cebae490877d561d" },
       "name": "Andrea Le",
-      "email": "andrea_le@fakegmail.com",
+      "email": "andrea_le@fake-mail.com",
       "version": 5,
       "scores": [ 85, 95, 75 ],
       "dateCreated": { "$date": "2003-03-26" }
-   }
-   
-Match Documents by UUID
-~~~~~~~~~~~~~~~~~~~~~~~
-            
-The following query filter finds documents where the UUID is
-"002636e1-10cd-4c8b-a9a7-01b7bfd3899c". 
-
-.. code-block:: shell
-
-   {_id: UUID('002636e1-10cd-4c8b-a9a7-01b7bfd3899c')}
-
-The query returns the following document:
-
-.. code-block:: JSON
-   :copyable: false
-
-   {
-      "_id": UUID('002636e1-10cd-4c8b-a9a7-01b7bfd3899c'),
-      "name": "Mr. Florencio Breitenberg",
-      "email": "Florencio.Breitenberg",
-      "phone": "876.349.6791 x616"
-      "website": "nelle.name",
-      "country": "Zimbabwe",
-      "age": 31
    }
 
 For more query examples, see 

--- a/source/query/filter.txt
+++ b/source/query/filter.txt
@@ -271,8 +271,7 @@ field value is later than June 22nd, 2000:
 
    { dateCreated: { $gt: Date('2000-06-22') } }
 
-The query returns the following documents because 
-the ``dateCreated`` field values are after June 22, 2000.
+The query returns the following documents:
 
 .. code-block:: JSON
    :copyable: false


### PR DESCRIPTION
## DESCRIPTION

Added two new examples to the Compass query bar page:

- Match on multiple conditions ($and)
- Match with $or.

As part of these updates, I reformatted the query bar examples to not use tabs. This way, the example headings appear in the right-hand toc and act as jump-list so users can quickly find examples. The new examples are noted in the in-line comments.

## STAGING

https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-32094/query/filter/#examples

## JIRA

https://jira.mongodb.org/browse/DOCSP-32094

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64da4b5b67dbe910108ee119

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)