### PR TITLE
DOCSP-32147 Legacy Connections

### DIFF
--- a/source/connect.txt
+++ b/source/connect.txt
@@ -44,6 +44,8 @@ Considerations
 
 - .. include:: /includes/fact-non-genuine-warning.rst
 
+- .. include:: /includes/fact-legacy-connections.rst
+
 Connect
 -------
 

--- a/source/connect/favorite-connections.txt
+++ b/source/connect/favorite-connections.txt
@@ -16,6 +16,10 @@ Favorite Connections
 easily reconnect to the same MongoDB deployment using the same
 specifications.
 
+.. note:: 
+   
+   .. include:: /includes/fact-legacy-connections.rst
+
 Save a Favorite Connection
 --------------------------
 

--- a/source/includes/fact-legacy-connections.rst
+++ b/source/includes/fact-legacy-connections.rst
@@ -4,5 +4,6 @@ internal |compass-short| connection-options format that is stored on disk and no
 longer supported after version 1.39.0. 
     
 If you have legacy connections saved in your favorites, export the 
-connections on version 1.39.0 to convert them into the new format before 
-updating to version 1.39.2.
+connections on `version 1.39.0 
+<https://github.com/mongodb-js/compass/releases/tag/v1.39.0>`_ to convert them 
+into the new format before updating to version 1.39.2.

--- a/source/includes/fact-legacy-connections.rst
+++ b/source/includes/fact-legacy-connections.rst
@@ -6,4 +6,4 @@ longer supported after version 1.39.0.
 If you have legacy connections saved in your favorites, export the 
 connections on `version 1.39.0 
 <https://github.com/mongodb-js/compass/releases/tag/v1.39.0>`_ to convert them 
-into the new format before updating to version 1.39.2.
+into the new format before updating to version 1.39.2 or later.


### PR DESCRIPTION
## DESCRIPTION
Make/edit note on legacy connections no longer being supported within Compass "Connect" and "Favorite Connections" pages. 
- Added a link to the created include to direct users to the 1.39.0 binary files.

## STAGING
- [Connect to MongoDB (Considerations)](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-32147-list-legacy-connections/connect/#considerations)
- [Favorite Connections ](https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-32147-list-legacy-connections/connect/favorite-connections/)- put here since legacy connections revolve around those that have been saved.

## JIRA
https://jira.mongodb.org/browse/DOCSP-32147

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64f787f924fcc731b48aaf28

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)