### PR TITLE
DOCSP-32260 adds atlas centric cta to pages

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -29,6 +29,7 @@ toc_landing_pages = [
 [constants]
 download-page = "`downloads page <https://www.mongodb.com/try/download/compass>`__"
 current-version = "1.39.3"
+atlas = "MongoDB Atlas"
 
 [[banners]]
 targets = [

--- a/snooty.toml
+++ b/snooty.toml
@@ -4,7 +4,8 @@ title = "MongoDB Compass"
 intersphinx = [
     "https://www.mongodb.com/docs/manual/objects.inv",
     "https://www.mongodb.com/docs/database-tools/objects.inv",
-    "https://www.mongodb.com/docs/mongodb-shell/objects.inv"
+    "https://www.mongodb.com/docs/mongodb-shell/objects.inv",
+    "https://www.mongodb.com/docs/atlas/objects.inv"
 ]
 
 toc_landing_pages = [
@@ -47,6 +48,7 @@ value = """
     """
 
 [substitutions]
+atlas = "MongoDB Atlas"
 compass = "MongoDB Compass"
 compass-short = "Compass"
 sql = ":abbr:`SQL (Structured Query Language)`"

--- a/source/includes/fact-atlas-compatible.rst
+++ b/source/includes/fact-atlas-compatible.rst
@@ -1,0 +1,4 @@
+You can |page-topic| for deployments hosted in the following
+environments:
+
+.. include:: /includes/fact-environments.rst

--- a/source/includes/fact-atlas-link.rst
+++ b/source/includes/fact-atlas-link.rst
@@ -1,0 +1,2 @@
+To learn more about |link-topic-ing| for deployments hosted in MongoDB
+Atlas, see |atlas-url|.

--- a/source/includes/fact-environments.rst
+++ b/source/includes/fact-environments.rst
@@ -1,5 +1,5 @@
 - `{+atlas+} 
-  <https://www.mongodb.com/docs/atlas?tck=docs_server>`__: The fully
+  <https://www.mongodb.com/docs/atlas>`__: The fully
   managed service for MongoDB deployments in the cloud
 - :ref:`MongoDB Enterprise <install-mdb-enterprise>`: The
   subscription-based, self-managed version of MongoDB

--- a/source/includes/fact-environments.rst
+++ b/source/includes/fact-environments.rst
@@ -1,0 +1,7 @@
+- `{+atlas+} 
+  <https://www.mongodb.com/docs/atlas?tck=docs_server>`__: The fully
+  managed service for MongoDB deployments in the cloud
+- :ref:`MongoDB Enterprise <install-mdb-enterprise>`: The
+  subscription-based, self-managed version of MongoDB
+- :ref:`MongoDB Community <install-mdb-community-edition>`: The
+  source available, free-to-use, and self-managed version of MongoDB

--- a/source/install.txt
+++ b/source/install.txt
@@ -10,7 +10,9 @@ Download and Install Compass
 
    |compass| doesn't support virtual desktop environments.
 
-You can connect to your {+atlas+} deployment with |compass|.
+You can connect to your `{+atlas+} <https://www.mongodb.com/docs/atlas>`
+deployment with |compass|. {+atlas+} is the fully managed service for
+MongoDB deployments in the cloud.
 
 To download and install |compass|, select your operating system:
 

--- a/source/install.txt
+++ b/source/install.txt
@@ -10,7 +10,9 @@ Download and Install Compass
 
    |compass| doesn't support virtual desktop environments.
 
-Select your operating system:
+You can connect to your {+atlas+} deployment with |compass|.
+
+To download and install |compass|, select your operating system:
 
 .. _software-reqs:
 

--- a/source/install.txt
+++ b/source/install.txt
@@ -10,7 +10,7 @@ Download and Install Compass
 
    |compass| doesn't support virtual desktop environments.
 
-You can connect to your `{+atlas+} <https://www.mongodb.com/docs/atlas>`
+You can connect to your `{+atlas+} <https://www.mongodb.com/docs/atlas>`__
 deployment with |compass|. {+atlas+} is the fully managed service for
 MongoDB deployments in the cloud.
 

--- a/source/query/filter.txt
+++ b/source/query/filter.txt
@@ -19,6 +19,16 @@ documents which match the specified criteria. To learn more about
 querying documents, see :manual:`Query Documents
 </tutorial/query-documents/>` in the MongoDB manual.
 
+Compatibility
+-------------
+
+.. |page-topic| replace:: query your data
+.. |link-topic-ing| replace:: querying your data
+.. |atlas-url| replace:: :atlas:`Find Specific Documents </atlas-ui/documents/#optional-specify-a-query-to-find-specific-documents>`
+
+.. include:: /includes/fact-atlas-compatible.rst
+.. include:: /includes/fact-atlas-link.rst
+
 Set Query Filter
 ----------------
 

--- a/source/query/sort.txt
+++ b/source/query/sort.txt
@@ -9,6 +9,16 @@ Sort the Returned Documents
 If the query bar displays the :guilabel:`Sort` option, you can specify
 the sort order of the returned documents.
 
+Compatibility
+-------------
+
+.. |page-topic| replace:: sort the returned documents
+.. |link-topic-ing| replace:: sorting returned documents
+.. |atlas-url| replace:: :atlas:`Sort Query Results <https://www.mongodb.com/docs/atlas/atlas-ui/documents/#sort-query-results>`
+
+.. include:: /includes/fact-atlas-compatible.rst
+.. include:: /includes/fact-atlas-link.rst
+
 Set the Sort Order
 ------------------
 

--- a/source/query/sort.txt
+++ b/source/query/sort.txt
@@ -14,7 +14,7 @@ Compatibility
 
 .. |page-topic| replace:: sort the returned documents
 .. |link-topic-ing| replace:: sorting returned documents
-.. |atlas-url| replace:: :atlas:`Sort Query Results <https://www.mongodb.com/docs/atlas/atlas-ui/documents/#sort-query-results>`
+.. |atlas-url| replace:: :atlas:`Sort Query Results </atlas-ui/documents/#sort-query-results>`
 
 .. include:: /includes/fact-atlas-compatible.rst
 .. include:: /includes/fact-atlas-link.rst


### PR DESCRIPTION
## DESCRIPTION


## STAGING
https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-32260/install/
https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-32260/query/filter/
https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-32260/query/sort/

## JIRA
https://jira.mongodb.org/browse/DOCSP-32260
https://jira.mongodb.org/browse/DOCSP-32261
https://jira.mongodb.org/browse/DOCSP-32031


## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64ff7b1524fcc731b43423ab


## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)