### PR TITLE
(DOCSP-29554): Ability to manage Atlas Search Indexes

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -16,6 +16,7 @@ toc_landing_pages = [
     "/connect/advanced-connection-options",
     "/connect/favorite-connections",
     "/connect/favorite-connections/import-export",
+    "/indexes",
     "/instance", 
     "/config-file",
     "/query/filter",

--- a/source/includes/steps-create-index.yaml
+++ b/source/includes/steps-create-index.yaml
@@ -1,4 +1,4 @@
-title: Click the :guilabel:`Create Index` button.
+title: Click the :guilabel:`Create Index` button
 level: 4
 ref: create-collection
 stepnum: 1
@@ -6,7 +6,7 @@ content: |
   From the :ref:`Indexes <collection-tab>` tab, click the
   :guilabel:`Create` button, then click :guilabel:`Index`.
 ---
-title: Optional. Enter the index name.
+title: Optional. Enter the index name
 level: 4
 ref: enter-index-name
 stepnum: 2
@@ -14,7 +14,7 @@ content: |
   In the dialog, enter the name of the index to create, or leave blank
   to have MongoDB create a default name for the index.
 ---
-title: Add fields to index.
+title: Add fields to the index
 level: 4
 ref: index-fields
 stepnum: 3
@@ -48,7 +48,7 @@ content: |
       :ref:`compass-wildcard-index`.
 
 ---
-title: Optional. Specify the index options.
+title: Optional. Specify index options
 level: 4
 ref: index-options
 stepnum: 4

--- a/source/includes/steps-create-index.yaml
+++ b/source/includes/steps-create-index.yaml
@@ -6,14 +6,6 @@ content: |
   From the :ref:`Indexes <collection-tab>` tab, click the
   :guilabel:`Create` button, then click :guilabel:`Index`.
 ---
-title: Optional. Enter the index name
-level: 4
-ref: enter-index-name
-stepnum: 2
-content: |
-  In the dialog, enter the name of the index to create. If you leave
-  this field blank, MongoDB creates the index with a default name.
----
 title: Add fields to the index
 level: 4
 ref: index-fields
@@ -64,19 +56,18 @@ content: |
        - Description
        - More Information
 
-     * - Build index in the background
-
-       - Ensure that the MongoDB deployment remains available during
-          the index build operation.
-
-       - :manual:`Background Construction </core/index-creation/index.html#background-construction>`
-
      * - Create unique index
 
        - Ensure that the indexed fields do not store duplicate values.
 
        - :manual:`Unique Indexes </core/index-unique>`
 
+     * - Index name
+
+       - Specify a name for the index.
+
+       - :ref:`specify-index-name`
+     
      * - Create a :abbr:`TTL (Time to Live)` index
 
        - Delete documents automatically after a specified number of

--- a/source/includes/steps-create-index.yaml
+++ b/source/includes/steps-create-index.yaml
@@ -3,8 +3,8 @@ level: 4
 ref: create-collection
 stepnum: 1
 content: |
-  From the :ref:`Indexes <collection-tab>` tab, click the
-  :guilabel:`Create` button, then click :guilabel:`Index`.
+  From the :ref:`Indexes <indexes-tab>` tab, click the :guilabel:`Create
+  Index` button.
 ---
 title: Add fields to the index
 level: 4
@@ -21,7 +21,7 @@ content: |
         index key, enter the field name in the input box.
 
       - To create a :manual:`compound index </core/index-compound/>`,
-        click the plus icon next to the index type dropdown.
+        click the :icon-fa5:`plus` icon next to the index type dropdown.
 
    b. Use the dropdown to the right of each field name to specify the
       index type. You can specify one of the following types:

--- a/source/includes/steps-create-index.yaml
+++ b/source/includes/steps-create-index.yaml
@@ -4,8 +4,7 @@ ref: create-collection
 stepnum: 1
 content: |
   From the :ref:`Indexes <collection-tab>` tab, click the
-  :guilabel:`Create Index` button to bring up the
-  :guilabel:`Create Index` dialog.
+  :guilabel:`Create` button, then click :guilabel:`Index`.
 ---
 title: Optional. Enter the index name.
 level: 4
@@ -26,15 +25,22 @@ content: |
       - To specify an existing document field as an index key, select
         the field from the dropdown list.
 
-      - To specify a field which does not exist in any document as an
+      - To specify a field that does not exist in any document as an
         index key, enter the field name in the input box.
 
       - To create a :manual:`compound index </core/index-compound/>`,
-        click :guilabel:`Add Another Field`.
+        click the plus icon next to the index type dropdown.
 
    b. Use the dropdown to the right of each field name to specify the
-      index type (``ascending``, ``descending``, or
-      :manual:`2dsphere </core/2dsphere/>`).
+      index type. You can specify one of the following types:
+      
+      - Ascending
+      
+      - Descending
+
+      - 2dsphere
+
+      - Text
 
    .. seealso::
 

--- a/source/includes/steps-create-index.yaml
+++ b/source/includes/steps-create-index.yaml
@@ -1,4 +1,4 @@
-title: Click the :guilabel:`Create Index` button
+title: Open the index creation dialog
 level: 4
 ref: create-collection
 stepnum: 1
@@ -11,8 +11,8 @@ level: 4
 ref: enter-index-name
 stepnum: 2
 content: |
-  In the dialog, enter the name of the index to create, or leave blank
-  to have MongoDB create a default name for the index.
+  In the dialog, enter the name of the index to create. If you leave
+  this field blank, MongoDB creates the index with a default name.
 ---
 title: Add fields to the index
 level: 4

--- a/source/indexes.txt
+++ b/source/indexes.txt
@@ -78,15 +78,12 @@ For each index, Compass displays the following information:
 Create an Index
 ---------------
 
-To create an index on a collection via Compass, the collection must
-contain documents.
-
 .. include:: /includes/steps/create-index.rst
 
 .. _compass-wildcard-index:
 
-Wildcard Indexes
-~~~~~~~~~~~~~~~~
+Create a Wildcard Index
+~~~~~~~~~~~~~~~~~~~~~~~
 
 .. versionadded:: v4.2
 
@@ -115,6 +112,16 @@ input.
 
    |compass-short| shows the type of your new index as
    :guilabel:`Wildcard`.
+
+Create an Atlas Search Index
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Atlas Search indexes let you query data in `Atlas Search
+<https://www.mongodb.com/docs/atlas/atlas-search/>`__. Atlas Search
+indexes enable performant text search queries by mapping search terms to
+the documents that contain those terms.
+
+
 
 .. _hide-index:
 

--- a/source/indexes.txt
+++ b/source/indexes.txt
@@ -83,8 +83,7 @@ Create an Index
 Create an Atlas Search Index
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To learn how to create an Atlas Search index, see
-:ref:`compass-create-search-index`.
+To create an Atlas Search index, see :ref:`compass-create-search-index`.
 
 .. _compass-wildcard-index:
 

--- a/source/indexes.txt
+++ b/source/indexes.txt
@@ -113,16 +113,6 @@ input.
    |compass-short| shows the type of your new index as
    :guilabel:`Wildcard`.
 
-Create an Atlas Search Index
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Atlas Search indexes let you query data in `Atlas Search
-<https://www.mongodb.com/docs/atlas/atlas-search/>`__. Atlas Search
-indexes enable performant text search queries by mapping search terms to
-the documents that contain those terms.
-
-
-
 .. _hide-index:
 
 Hide or Unhide an Index
@@ -168,3 +158,8 @@ Limitations
 
 - The :guilabel:`Indexes` tab is not available if you are connected 
   to a :atlas:`Data Lake </data-lake>`. 
+
+.. toctree::
+   :titlesonly:
+
+   /indexes/create-search-index

--- a/source/indexes.txt
+++ b/source/indexes.txt
@@ -80,6 +80,9 @@ Create an Index
 
 .. include:: /includes/steps/create-index.rst
 
+Create an Atlas Search Index
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 To learn how to create an Atlas Search index, see
 :ref:`compass-create-search-index`.
 

--- a/source/indexes.txt
+++ b/source/indexes.txt
@@ -80,6 +80,9 @@ Create an Index
 
 .. include:: /includes/steps/create-index.rst
 
+To learn how to create an Atlas Search index, see
+:ref:`compass-create-search-index`.
+
 .. _compass-wildcard-index:
 
 Create a Wildcard Index

--- a/source/indexes.txt
+++ b/source/indexes.txt
@@ -13,8 +13,8 @@ Manage Indexes
    :class: singlecol
 
 Indexes are special data structures that improve query performance.
-Indexes store a portion of a collection's data in an easy-to-traverse 
-form. The index stores the value of a specific field or set of fields, 
+Indexes store a portion of a collection's data in an easy-to-traverse
+form. The index stores the value of a specific field or set of fields,
 ordered by the value of the field.
 
 To improve query performance, build indexes on fields that appear often 

--- a/source/indexes/create-search-index.txt
+++ b/source/indexes/create-search-index.txt
@@ -1,0 +1,68 @@
+.. _compass-create-search-index:
+
+============================
+Create an Atlas Search Index
+============================
+
+You can create Atlas Search indexes in |compass|. Atlas Search indexes
+let you query data in `Atlas Search
+<https://www.mongodb.com/docs/atlas/atlas-search/>`__. Atlas Search
+indexes enable performant text search queries by mapping search terms to
+the documents that contain those terms.
+
+About this Task
+---------------
+
+To create an Atlas Search index, your deployment must be hosted on
+`MongoDB Atlas <https://www.mongodb.com/docs/atlas/>`__ and have a
+cluster tier of M10 or higher.
+
+Steps
+-----
+
+.. procedure::
+   :style: normal
+   
+   .. step:: Open the index creation dialog
+
+      From the :ref:`Indexes <collection-tab>` tab, click the
+      :guilabel:`Create` button, then click :guilabel:`Search Index`.
+
+   .. step:: Enter the index name
+
+      Specify a name for the index.
+
+   .. step:: Specify the search index definition
+
+      |compass-short| provides templates for different kinds of search
+      indexes. To learn more about search index definition syntax, see
+      `Review Atlas Search Index Syntax
+      <https://www.mongodb.com/docs/atlas/atlas-search/index-definitions/>`__.
+
+   .. step:: Click :guiablel:`Create Search Index`. 
+
+Example
+-------
+
+The following example search index definition creates a search
+index that excludes the ``director`` and ``imdb.rating`` fields:
+
+.. code-block:: javascript
+
+   {
+      mappings: { dynamic: true },
+      storedSource: {
+         exclude: [ "directors", "imdb.rating" ]
+      }
+   }
+
+Learn More
+----------
+
+- :ref:`compass-indexes`
+
+- `Define Atlas Search Field Mappings
+  <https://www.mongodb.com/docs/atlas/atlas-search/define-field-mappings/>`__
+
+- `Define Synonym Mappings in Your Atlas Search Index
+  <https://www.mongodb.com/docs/atlas/atlas-search/synonyms/>`__

--- a/source/indexes/create-search-index.txt
+++ b/source/indexes/create-search-index.txt
@@ -38,7 +38,7 @@ Steps
       indexes. To learn more about search index definition syntax, see
       :ref:`search-index-definition-create-mongosh`.
 
-   .. step:: Click :guilabel:`Create Search Index`. 
+   .. step:: Click :guilabel:`Create Search Index`
 
 Example
 -------

--- a/source/indexes/create-search-index.txt
+++ b/source/indexes/create-search-index.txt
@@ -36,8 +36,7 @@ Steps
 
       |compass-short| provides templates for different kinds of search
       indexes. To learn more about search index definition syntax, see
-      `Review Atlas Search Index Syntax
-      <https://www.mongodb.com/docs/atlas/atlas-search/index-definitions/>`__.
+      :ref:`search-index-definition-create-mongosh`.
 
    .. step:: Click :guiablel:`Create Search Index`. 
 

--- a/source/indexes/create-search-index.txt
+++ b/source/indexes/create-search-index.txt
@@ -67,6 +67,18 @@ the ``directors`` and ``imdb.rating`` fields:
       }
    }
 
+Results
+-------
+
+To view the status of your created index, go to the :guilabel:`Indexes`
+tab and set the toggle at the top-right to :guilabel:`Search Indexes`.
+
+The :guilabel:`Status` column indicates the status of the index. When
+the status is :guilabel:`Ready`, your index is ready to be used.
+
+For more information on search index statuses, see
+:ref:`search-index-status`.
+
 Learn More
 ----------
 

--- a/source/indexes/create-search-index.txt
+++ b/source/indexes/create-search-index.txt
@@ -40,9 +40,7 @@ Steps
       From the :ref:`Indexes <indexes-tab>` tab, click the
       :guilabel:`Create` button, then click :guilabel:`Search Index`.
 
-   .. step:: Enter the index name
-
-      Specify a name for the index.
+   .. step:: Specify a name for the index
 
    .. step:: Specify the search index definition
 

--- a/source/indexes/create-search-index.txt
+++ b/source/indexes/create-search-index.txt
@@ -38,7 +38,7 @@ Steps
       indexes. To learn more about search index definition syntax, see
       :ref:`search-index-definition-create-mongosh`.
 
-   .. step:: Click :guiablel:`Create Search Index`. 
+   .. step:: Click :guilabel:`Create Search Index`. 
 
 Example
 -------

--- a/source/indexes/create-search-index.txt
+++ b/source/indexes/create-search-index.txt
@@ -43,7 +43,7 @@ Steps
    .. step:: Specify the search index definition
 
       |compass-short| provides templates for different kinds of search
-      indexes. To learn more about search index definition syntax, see
+      indexes. To learn more, see
       :ref:`search-index-definition-create-mongosh`.
 
    .. step:: Click :guilabel:`Create Search Index`

--- a/source/indexes/create-search-index.txt
+++ b/source/indexes/create-search-index.txt
@@ -4,6 +4,14 @@
 Create an Atlas Search Index
 ============================
 
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+.. versionadded:: 1.40.0
+
 You can create Atlas Search indexes in |compass|. Atlas Search indexes
 let you query data in `Atlas Search
 <https://www.mongodb.com/docs/atlas/atlas-search/>`__. Atlas Search
@@ -25,7 +33,7 @@ Steps
    
    .. step:: Open the index creation dialog
 
-      From the :ref:`Indexes <collection-tab>` tab, click the
+      From the :ref:`Indexes <indexes-tab>` tab, click the
       :guilabel:`Create` button, then click :guilabel:`Search Index`.
 
    .. step:: Enter the index name
@@ -43,8 +51,8 @@ Steps
 Example
 -------
 
-The following example search index definition creates a search
-index that excludes the ``directors`` and ``imdb.rating`` fields:
+The following example definition creates a search index that excludes
+the ``directors`` and ``imdb.rating`` fields:
 
 .. code-block:: javascript
 

--- a/source/indexes/create-search-index.txt
+++ b/source/indexes/create-search-index.txt
@@ -45,7 +45,7 @@ Example
 -------
 
 The following example search index definition creates a search
-index that excludes the ``director`` and ``imdb.rating`` fields:
+index that excludes the ``directors`` and ``imdb.rating`` fields:
 
 .. code-block:: javascript
 

--- a/source/indexes/create-search-index.txt
+++ b/source/indexes/create-search-index.txt
@@ -21,9 +21,13 @@ the documents that contain those terms.
 About this Task
 ---------------
 
-To create an Atlas Search index, your deployment must be hosted on
-`MongoDB Atlas <https://www.mongodb.com/docs/atlas/>`__ and have a
-cluster tier of M10 or higher.
+To create an Atlas Search index must meet the following requirements:
+
+- Hosted on `MongoDB Atlas <https://www.mongodb.com/docs/atlas/>`__
+
+- Atlas cluster tier of M10 or higher
+
+- MongoDB version of 7.0 or later
 
 Steps
 -----

--- a/source/indexes/create-search-index.txt
+++ b/source/indexes/create-search-index.txt
@@ -21,13 +21,15 @@ the documents that contain those terms.
 About this Task
 ---------------
 
-To create an Atlas Search index must meet the following requirements:
+To create an Atlas Search index, your deployment must be either:
 
-- Hosted on `MongoDB Atlas <https://www.mongodb.com/docs/atlas/>`__
+- Hosted on `MongoDB Atlas <https://www.mongodb.com/docs/atlas/>`__ and
+  have an Atlas cluster tier of M10 or higher.
 
-- Atlas cluster tier of M10 or higher
+- A local deployment that is set up using the `Atlas CLI
+  <https://www.mongodb.com/docs/atlas/cli/stable/atlas-cli-deploy-local/>`__.
 
-- MongoDB version of 7.0 or later
+Additionally, your deployment must run MongoDB version 7.0 or later.
 
 Steps
 -----
@@ -53,16 +55,13 @@ Steps
 Example
 -------
 
-The following example definition creates a search index that excludes
-the ``directors`` and ``imdb.rating`` fields:
+The following example definition creates a search index that indexes all
+fields:
 
 .. code-block:: javascript
 
    {
-      mappings: { dynamic: true },
-      storedSource: {
-         exclude: [ "directors", "imdb.rating" ]
-      }
+      mappings: { dynamic: true }
    }
 
 Results


### PR DESCRIPTION
## DESCRIPTION

Document that you can manage Atlas Search indexes in Compass. For details about Atlas Search index syntax, we will point users to the Atlas docs.

## STAGING

- [Manage Indexes](https://preview-mongodbjeffallenmongo.gatsbyjs.io/compass/DOCSP-29554/indexes/)
- [Create an Atlas Search Index](https://preview-mongodbjeffallenmongo.gatsbyjs.io/compass/DOCSP-29554/indexes/create-search-index/#std-label-compass-create-search-index)

## JIRA

https://jira.mongodb.org/browse/DOCSP-29554

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=651301c4492df295cff67a72

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)