### PR TITLE
DOCSP-33413 Add Electron Release Notes Link to Compass

### DIFF
--- a/source/collections.txt
+++ b/source/collections.txt
@@ -8,7 +8,7 @@ Collections
 
 .. facet::
    :name: genre
-   :values:: tutorial
+   :values: tutorial
 
 .. contents:: On this page
    :local:

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -8,7 +8,7 @@ Connect to MongoDB
 
 .. facet::
    :name: genre
-   :values:: tutorial
+   :values: tutorial
 
 .. meta:: 
    :keywords: atlas, server

--- a/source/import-export.txt
+++ b/source/import-export.txt
@@ -12,7 +12,7 @@ Import and Export Data
 
 .. facet::
    :name: genre
-   :values:: tutorial
+   :values: tutorial
 
 .. contents:: On this page
    :local:

--- a/source/install.txt
+++ b/source/install.txt
@@ -8,7 +8,7 @@ Download and Install Compass
 
 .. facet::
    :name: genre
-   :values:: tutorial
+   :values: tutorial
 
 .. important:: 
 

--- a/source/query/filter.txt
+++ b/source/query/filter.txt
@@ -10,7 +10,7 @@ Query Your Data
 
 .. facet::
    :name: genre
-   :values:: tutorial
+   :values: tutorial
 
 .. meta:: 
    :keywords: sample dataset

--- a/source/query/queries.txt
+++ b/source/query/queries.txt
@@ -8,7 +8,7 @@ Managing Saved Queries and Aggregations
 
 .. facet::
    :name: genre
-   :values:: tutorial
+   :values: tutorial
 
 .. meta:: 
    :keywords: sample dataset

--- a/source/query/sort.txt
+++ b/source/query/sort.txt
@@ -8,7 +8,7 @@ Sort the Returned Documents
 
 .. facet::
    :name: genre
-   :values:: tutorial
+   :values: tutorial
 
 If the query bar displays the :guilabel:`Sort` option, you can specify
 the sort order of the returned documents.

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -56,7 +56,7 @@ New Features:
   
 - Upgrade Node driver to version 6.0.0 (:issue:`COMPASS-7057`).
 
-- Upgrade Electron to version 26.
+- Upgrade Electron to `version 26 <https://releases.electronjs.org/release/v26.2.2>`__.
 
 - Set up local Atlas detection (:issue:`COMPASS-7213`).
 


### PR DESCRIPTION
## DESCRIPTION
Add link to Electron v26.2.2 release notes to Compass 1.40.0 RN. 

## STAGING
https://preview-mongodbajhuhmdb.gatsbyjs.io/compass/DOCSP-33413-compass-electron-rn/release-notes/#:~:text=Upgrade%20Electron%20to,version%2026.

## JIRA
https://jira.mongodb.org/browse/DOCSP-33413

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=651c5763492df295cf2a618b
## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)