### PR TITLE
Updated banner text, added doc constants

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "esbonio.server.enabled": true,
-    "esbonio.sphinx.confDir": ""
-}

--- a/snooty.toml
+++ b/snooty.toml
@@ -40,14 +40,12 @@ targets = [
     "collections/encrypted-collection.txt",
 ]
 
-variant = "danger"
+variant = "warning"
 value = """
-    Queryable Encryption is in Public Preview and available for \
-    evaluation purposes. Public Preview is not recommended for \
-    production deployments as breaking changes may be introduced. \
-    To learn more about the Preview please see the \
-    `Queryable Encryption Preview <https://www.mongodb.com/blog/post/mongodb-releases-queryable-encryption-preview/>`__ \
-    blog post.
+    {+qe-equality-ga+} is generally available (GA) in MongoDB 7.0 and \
+    later. The {+qe-preview+}, released in version 6.0, is no longer supported. \
+    Data encrypted using the Public Preview is incompatible with the feature release. \
+    For more information, see :ref:`7.0-compatibility`.
     """
 
 [[banners]]
@@ -73,3 +71,6 @@ service = "Atlas"
 json = ":abbr:`JSON (Javascript Object Notation)`"
 bson = ":abbr:`BSON (Binary Javascript Object Notation)`"
 checkmark = "√"
+qe = "Queryable Encryption"
+qe-preview = "{+qe+} Public Preview"
+qe-equality-ga = "{+qe+} with equality queries"

--- a/snooty.toml
+++ b/snooty.toml
@@ -33,6 +33,19 @@ download-page = "`downloads page <https://www.mongodb.com/try/download/compass>`
 current-version = "1.40.4"
 atlas = "MongoDB Atlas"
 
+[substitutions]
+atlas = "MongoDB Atlas"
+compass = "MongoDB Compass"
+compass-short = "Compass"
+sql = ":abbr:`SQL (Structured Query Language)`"
+service = "Atlas"
+json = ":abbr:`JSON (Javascript Object Notation)`"
+bson = ":abbr:`BSON (Binary Javascript Object Notation)`"
+checkmark = "√"
+qe = "Queryable Encryption"
+qe-preview = "{+qe+} Public Preview"
+qe-equality-ga = "{+qe+} with equality queries"
+
 [[banners]]
 targets = [
     "connect/in-use-encryption.txt",
@@ -61,16 +74,3 @@ value = """
     available as a **Public Preview** offering. The product, its features, \ 
     and the corresponding documentation may change during the Preview stage.
     """
-
-[substitutions]
-atlas = "MongoDB Atlas"
-compass = "MongoDB Compass"
-compass-short = "Compass"
-sql = ":abbr:`SQL (Structured Query Language)`"
-service = "Atlas"
-json = ":abbr:`JSON (Javascript Object Notation)`"
-bson = ":abbr:`BSON (Binary Javascript Object Notation)`"
-checkmark = "√"
-qe = "Queryable Encryption"
-qe-preview = "{+qe+} Public Preview"
-qe-equality-ga = "{+qe+} with equality queries"

--- a/snooty.toml
+++ b/snooty.toml
@@ -32,16 +32,6 @@ toc_landing_pages = [
 download-page = "`downloads page <https://www.mongodb.com/try/download/compass>`__"
 current-version = "1.40.4"
 atlas = "MongoDB Atlas"
-
-[substitutions]
-atlas = "MongoDB Atlas"
-compass = "MongoDB Compass"
-compass-short = "Compass"
-sql = ":abbr:`SQL (Structured Query Language)`"
-service = "Atlas"
-json = ":abbr:`JSON (Javascript Object Notation)`"
-bson = ":abbr:`BSON (Binary Javascript Object Notation)`"
-checkmark = "√"
 qe = "Queryable Encryption"
 qe-preview = "{+qe+} Public Preview"
 qe-equality-ga = "{+qe+} with equality queries"
@@ -74,3 +64,13 @@ value = """
     available as a **Public Preview** offering. The product, its features, \ 
     and the corresponding documentation may change during the Preview stage.
     """
+
+[substitutions]
+atlas = "MongoDB Atlas"
+compass = "MongoDB Compass"
+compass-short = "Compass"
+sql = ":abbr:`SQL (Structured Query Language)`"
+service = "Atlas"
+json = ":abbr:`JSON (Javascript Object Notation)`"
+bson = ":abbr:`BSON (Binary Javascript Object Notation)`"
+checkmark = "√"

--- a/source/in-use-encryption-tutorial.txt
+++ b/source/in-use-encryption-tutorial.txt
@@ -12,8 +12,9 @@ In-Use Encryption Tutorial
    :depth: 1
    :class: singlecol
 
-In-Use Encryption allows you to connect to your deployments using :v7.0:`{+qe+} </core/queryable-encryption/>`. This connection method allows you to 
-encrypt a subset of fields in your collections. 
+In-Use Encryption allows you to connect to your deployments using 
+:v7.0:`{+qe+} </core/queryable-encryption/>`. This connection method
+allows you to encrypt a subset of fields in your collections. 
 
 You can also use :manual:`CSFLE </core/csfle/>` to encrypt a subset of fields 
 in your collection. CSFLE encryption is enabled through the schema editor.

--- a/source/in-use-encryption-tutorial.txt
+++ b/source/in-use-encryption-tutorial.txt
@@ -12,8 +12,7 @@ In-Use Encryption Tutorial
    :depth: 1
    :class: singlecol
 
-In-Use Encryption allows you to connect to your deployments using :v7.0:`Queryable 
-Encryption </core/queryable-encryption/>`. This connection method allows you to 
+In-Use Encryption allows you to connect to your deployments using :v7.0:`{+qe+} </core/queryable-encryption/>`. This connection method allows you to 
 encrypt a subset of fields in your collections. 
 
 You can also use :manual:`CSFLE </core/csfle/>` to encrypt a subset of fields 
@@ -23,7 +22,7 @@ Overview
 --------
 
 This guide shows you how to connect to your deployment and collections using 
-Queryable Encryption. 
+{+qe+}. 
 
 This guide uses the `air_airlines.json <https://raw.githubusercontent.com/mongodb/docs-assets/compass/air_airlines.json>`__
 data set in the guided examples. The guide covers the process of importing 
@@ -45,7 +44,7 @@ Create Your Encrypted Collection
 --------------------------------
 
 Once your deployment is connected using In-Use Encryption, create your collection 
-using Queryable Encryption. You can create a new database and collection or you 
+using {+qe+}. You can create a new database and collection or you 
 can create a new collection in an existing database.
 
 {+qe+} supports new collections only. You can't enable {+qe+} 
@@ -64,7 +63,7 @@ Procedure
 
    .. step:: Click the :guilabel:`Advanced Collection Options` drop down. 
 
-   .. step:: Check the :guilabel:`Queryable Encryption` box.
+   .. step:: Check the :guilabel:`{+qe+}` box.
 
    .. step:: Specify your :guilabel:`Encrypted Fields`. 
 
@@ -94,7 +93,7 @@ Import Your Data
 
    .. step:: Click on your collection on the left-hand navigation banner.
 
-      The collection has a :guilabel:`Queryable Encryption` badge next to 
+      The collection has a :guilabel:`{+qe+}` badge next to 
       its name to indicate that fields in that collection are encrypted.
 
    .. step:: Click :guilabel:`Add Data`.

--- a/source/in-use-encryption-tutorial.txt
+++ b/source/in-use-encryption-tutorial.txt
@@ -12,7 +12,7 @@ In-Use Encryption Tutorial
    :depth: 1
    :class: singlecol
 
-In-Use Encryption allows you to connect to your deployments using :v6.0:`Queryable 
+In-Use Encryption allows you to connect to your deployments using :v7.0:`Queryable 
 Encryption </core/queryable-encryption/>`. This connection method allows you to 
 encrypt a subset of fields in your collections. 
 
@@ -48,6 +48,9 @@ Once your deployment is connected using In-Use Encryption, create your collectio
 using Queryable Encryption. You can create a new database and collection or you 
 can create a new collection in an existing database.
 
+{+qe+} supports new collections only. You can't enable {+qe+} 
+on existing collections.
+
 Procedure
 ~~~~~~~~~
 
@@ -75,11 +78,11 @@ Procedure
       Here, the encrypted field is the ``base`` field of the ``air_airlines`` 
       data set.  
 
-      For more information, see :v6.0:`Encrypted Fields </core/queryable-encryption/fundamentals/encrypt-and-query/>`.
+      For more information, see :v7.0:`Encrypted Fields </core/queryable-encryption/fundamentals/encrypt-and-query/>`.
 
-   .. step:: (Optional) Specify :v6.0:`KMS Provider </core/queryable-encryption/fundamentals/kms-providers/>`.  
+   .. step:: (Optional) Specify :v7.0:`KMS Provider </core/queryable-encryption/fundamentals/kms-providers/>`.  
 
-   .. step:: (Optional) Specify :v6.0:`Key Encryption Key </core/queryable-encryption/fundamentals/keys-key-vaults/>`.
+   .. step:: (Optional) Specify :v7.0:`Key Encryption Key </core/queryable-encryption/fundamentals/keys-key-vaults/>`.
 
    .. step:: Click :guilabel:`Create Database` or :guilabel:`Create Collection`.
 


### PR DESCRIPTION
## DESCRIPTION
Updates banners in Compass to get rid of 6.0 QE "Public Preview" language

## STAGING
[In-Use Encryption Tutorial](https://preview-mongodbnvillahermosamdb.gatsbyjs.io/compass/DOCSP-33682-fix-QE-banners/in-use-encryption-tutorial/)
Compass v7.0 docs


## JIRA
https://jira.mongodb.org/browse/DOCSP-33682

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=653fca38bd8a7a957943d658

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)