### PR TITLE
DOCSP-33792 match by date error

### DIFF
--- a/source/query/filter.txt
+++ b/source/query/filter.txt
@@ -286,7 +286,7 @@ field value is later than June 22nd, 2000:
 
 .. code-block:: shell
 
-   { dateCreated: { $gt: Date('2000-06-22') } }
+   { dateCreated: { $gt: new Date('2000-06-22') } }
 
 The query returns the following documents:
 


### PR DESCRIPTION
## DESCRIPTION

adding "new" to match by date example

## STAGING

https://preview-mongodbltranmdb2.gatsbyjs.io/compass/DOCSP-33792/query/filter/#match-by-date

## JIRA

https://jira.mongodb.org/browse/DOCSP-33792

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65491c4abd8a7a957951a2d2

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)