### PR TITLE
DOCSP-23996 Add enableUtf8Validation Connectionstring Option

### DIFF
--- a/source/connect/advanced-connection-options/advanced-connection.txt
+++ b/source/connect/advanced-connection-options/advanced-connection.txt
@@ -22,10 +22,9 @@ for your deployment. These options can be used with the
 About this Task
 ---------------
 
-The ``enableUtf8Validation`` URI option is supported by the
-:driver:`Node </node>` driver and Compass. This option allows 
-Compass to display collections that have invalid UTF8 data. For details, 
-see 
+The ``enableUtf8Validation`` URI option is supported Compass. This 
+option allows Compass to display collections that have invalid UTF8 
+data. For details, see 
 :ref:`disabling UTF-8 Validation<compass-advanced-connection-examples>`.
 
 Steps

--- a/source/connect/advanced-connection-options/advanced-connection.txt
+++ b/source/connect/advanced-connection-options/advanced-connection.txt
@@ -105,25 +105,6 @@ Steps
 
    .. step:: Click Connect.
 
-   .. step:: (Optional) Resolve Data Display Issues
-
-      If Compass is having issues displaying data and returning the error
-      message ``Invalid UTF-8 string in BSON document.``, you can set the 
-      ``enableUtf8Validation`` URI option. 
-
-      The following connection string disables UTF8 validation:
-
-      .. code-block:: javascript
-
-          mongodb://localhost:27017/?enableUtf8Validation=false
-
-      .. note::
-
-        You can also disable this option in the 
-        :guilabel:`Advanced Connection Options` by 
-        selecting the key :guilabel:`enableUtf8Validation` and entering 
-        the value ``false``.
-
 .. seealso::
 
    To disconnect from your deployment, see :ref:`<disconnect-tab>`. 

--- a/source/connect/advanced-connection-options/advanced-connection.txt
+++ b/source/connect/advanced-connection-options/advanced-connection.txt
@@ -127,11 +127,11 @@ The following connection string disables UTF8 validation:
 
 .. code-block:: javascript
 
-    mongodb://localhost:27017/?enableUtf8Validation=False
+    mongodb://localhost:27017/?enableUtf8Validation=false
 
 .. note::
 
   You can also disable this option in the 
   :guilabel:`Advanced Connection Options` by 
   selecting the key :guilabel:`enableUtf8Validation` and entering 
-  the value ``False``.
+  the value ``false``.

--- a/source/connect/advanced-connection-options/advanced-connection.txt
+++ b/source/connect/advanced-connection-options/advanced-connection.txt
@@ -106,7 +106,7 @@ Procedure
 
     .. note::
 
-      The ``enableUtf8Validation`` connection string parameter is only 
+      The ``enableUtf8Validation`` URI option is only 
       supported by the ``nodejs`` driver and Compass. This option 
       allows Compass to display collections which have invalid UTF8 
       data. To set this parameter you can pass set the ``enableUtf8Validation``
@@ -115,7 +115,7 @@ Procedure
 
       For example:
 
-      ```mongodb://localhost:27017/?enableUtf8Validation=True``
+      ``mongodb://localhost:27017/?enableUtf8Validation=True``
       
    .. step:: Click Connect.
 

--- a/source/connect/advanced-connection-options/advanced-connection.txt
+++ b/source/connect/advanced-connection-options/advanced-connection.txt
@@ -12,15 +12,25 @@ Advanced Connection Tab
    :depth: 1
    :class: singlecol
 
-
 The :guilabel:`Advanced` connection tab provides additional connection options 
 for your deployment. These options can be used with the 
 :ref:`General <general-connection-tab>`, :ref:`Authentication 
 <authentication-connection-tab>`, :ref:`TLS / SSL <tls-ssl-tab>`, and 
 :ref:`Proxy / SSH Tunnel <ssh-connection>` connection options. 
 
-Procedure
----------
+
+About this Task
+---------------
+
+The ``enableUtf8Validation`` URI option is only 
+supported by the ``nodejs`` driver and Compass. This option 
+allows Compass to display collections which have invalid UTF8 
+data. To set this parameter you can pass set the ``enableUtf8Validation``
+parameter in the connection string or use the advanced connections 
+tab in Compass. For details, see :ref:`compass-advanced-connection-examples`.
+
+Steps
+-----
 
 .. procedure::
    :style: normal
@@ -104,21 +114,20 @@ Procedure
              For more information, see :manual:`Connection String Options 
              </reference/connection-string/#connection-string-options>`.
 
-    .. note::
-
-      The ``enableUtf8Validation`` URI option is only 
-      supported by the ``nodejs`` driver and Compass. This option 
-      allows Compass to display collections which have invalid UTF8 
-      data. To set this parameter you can pass set the ``enableUtf8Validation``
-      parameter in the connection string or use the advanced connections 
-      tab in Compass.
-
-      For example:
-
-      ``mongodb://localhost:27017/?enableUtf8Validation=True``
-      
    .. step:: Click Connect.
 
 .. seealso::
 
    To disconnect from your deployment, see :ref:`<disconnect-tab>`. 
+
+.. _compass-advanced-connection-examples:
+
+Example
+-------
+
+The following code shows an example of a connection string that uses
+utf8 validation:
+
+.. code-block:: javascript
+
+    mongodb://localhost:27017/?enableUtf8Validation=True

--- a/source/connect/advanced-connection-options/advanced-connection.txt
+++ b/source/connect/advanced-connection-options/advanced-connection.txt
@@ -25,8 +25,8 @@ About this Task
 The ``enableUtf8Validation`` URI option is only 
 supported by the ``nodejs`` driver and Compass. This option 
 allows Compass to display collections which have invalid UTF8 
-data. To set this parameter you can pass set the ``enableUtf8Validation``
-parameter in the connection string or use the advanced connections 
+data. To set this parameter you can set the ``enableUtf8Validation``
+value in the connection string or use the advanced connections 
 tab in Compass. For details, see
 :ref:`disable UTF-8 Validation<compass-advanced-connection-examples>`.
 

--- a/source/connect/advanced-connection-options/advanced-connection.txt
+++ b/source/connect/advanced-connection-options/advanced-connection.txt
@@ -22,10 +22,11 @@ for your deployment. These options can be used with the
 About this Task
 ---------------
 
-The ``enableUtf8Validation`` URI option is supported by the ``nodejs`` 
-driver and Compass. This option allows Compass to display collections 
-which have invalid UTF8 data. For details, see
-:ref:`disable UTF-8 Validation<compass-advanced-connection-examples>`.
+The ``enableUtf8Validation`` URI option is supported by the
+:driver:`Node </node>` driver and Compass. This option allows 
+Compass to display collections that have invalid UTF8 data. For details, 
+see 
+:ref:`disabling UTF-8 Validation<compass-advanced-connection-examples>`.
 
 Steps
 -----

--- a/source/connect/advanced-connection-options/advanced-connection.txt
+++ b/source/connect/advanced-connection-options/advanced-connection.txt
@@ -131,3 +131,10 @@ The following connection string disables UTF8 validation:
 .. code-block:: javascript
 
     mongodb://localhost:27017/?enableUtf8Validation=False
+
+.. note::
+
+  You can also disable this option in the 
+  :guilabel:`Advanced Connection Options` by 
+  selecting the key :guilabel:`enableUtf8Validation` and typing 
+  the value ``False``.

--- a/source/connect/advanced-connection-options/advanced-connection.txt
+++ b/source/connect/advanced-connection-options/advanced-connection.txt
@@ -126,8 +126,7 @@ Steps
 Example
 -------
 
-The following code shows an example of a connection string that disables
-UTF8 validation:
+The following connection string disables UTF8 validation:
 
 .. code-block:: javascript
 

--- a/source/connect/advanced-connection-options/advanced-connection.txt
+++ b/source/connect/advanced-connection-options/advanced-connection.txt
@@ -12,6 +12,7 @@ Advanced Connection Tab
    :depth: 1
    :class: singlecol
 
+
 The :guilabel:`Advanced` connection tab provides additional connection options 
 for your deployment. These options can be used with the 
 :ref:`General <general-connection-tab>`, :ref:`Authentication 

--- a/source/connect/advanced-connection-options/advanced-connection.txt
+++ b/source/connect/advanced-connection-options/advanced-connection.txt
@@ -133,5 +133,5 @@ The following connection string disables UTF8 validation:
 
   You can also disable this option in the 
   :guilabel:`Advanced Connection Options` by 
-  selecting the key :guilabel:`enableUtf8Validation` and typing 
+  selecting the key :guilabel:`enableUtf8Validation` and entering 
   the value ``False``.

--- a/source/connect/advanced-connection-options/advanced-connection.txt
+++ b/source/connect/advanced-connection-options/advanced-connection.txt
@@ -104,6 +104,14 @@ Procedure
              For more information, see :manual:`Connection String Options 
              </reference/connection-string/#connection-string-options>`.
 
+    .. note::
+
+      There are a few connection string parameters which are supported 
+      only by the ``nodejs`` driver. For details on all supported node
+      specific connection string parameters see 
+      `Node Connection Options 
+      <https://www.mongodb.com/docs/drivers/node/current/fundamentals/connection/connection-options/>`__.
+
    .. step:: Click Connect.
 
 .. seealso::

--- a/source/connect/advanced-connection-options/advanced-connection.txt
+++ b/source/connect/advanced-connection-options/advanced-connection.txt
@@ -27,7 +27,8 @@ supported by the ``nodejs`` driver and Compass. This option
 allows Compass to display collections which have invalid UTF8 
 data. To set this parameter you can pass set the ``enableUtf8Validation``
 parameter in the connection string or use the advanced connections 
-tab in Compass. For details, see :ref:`compass-advanced-connection-examples`.
+tab in Compass. For details, see
+:ref:`disable UTF-8 Validation<compass-advanced-connection-examples>`.
 
 Steps
 -----
@@ -125,9 +126,9 @@ Steps
 Example
 -------
 
-The following code shows an example of a connection string that uses
-utf8 validation:
+The following code shows an example of a connection string that disables
+UTF8 validation:
 
 .. code-block:: javascript
 
-    mongodb://localhost:27017/?enableUtf8Validation=True
+    mongodb://localhost:27017/?enableUtf8Validation=False

--- a/source/connect/advanced-connection-options/advanced-connection.txt
+++ b/source/connect/advanced-connection-options/advanced-connection.txt
@@ -22,12 +22,9 @@ for your deployment. These options can be used with the
 About this Task
 ---------------
 
-The ``enableUtf8Validation`` URI option is only 
-supported by the ``nodejs`` driver and Compass. This option 
-allows Compass to display collections which have invalid UTF8 
-data. To set this parameter you can set the ``enableUtf8Validation``
-value in the connection string or use the advanced connections 
-tab in Compass. For details, see
+The ``enableUtf8Validation`` URI option is supported by the ``nodejs`` 
+driver and Compass. This option allows Compass to display collections 
+which have invalid UTF8 data. For details, see
 :ref:`disable UTF-8 Validation<compass-advanced-connection-examples>`.
 
 Steps

--- a/source/connect/advanced-connection-options/advanced-connection.txt
+++ b/source/connect/advanced-connection-options/advanced-connection.txt
@@ -18,28 +18,19 @@ for your deployment. These options can be used with the
 <authentication-connection-tab>`, :ref:`TLS / SSL <tls-ssl-tab>`, and 
 :ref:`Proxy / SSH Tunnel <ssh-connection>` connection options. 
 
-
-About this Task
----------------
-
-The ``enableUtf8Validation`` URI option is supported by Compass. This 
-option allows Compass to display collections that have invalid UTF8 
-data. For details, see 
-:ref:`disabling UTF-8 Validation<compass-advanced-connection-examples>`.
-
 Steps
 -----
 
 .. procedure::
    :style: normal
 
-   .. step:: Click :guilabel:`Advanced Connection Options`.
+   .. step:: Click :guilabel:`Advanced Connection Options`
 
       .. figure:: /images/compass/advanced-connection-options.png
          :figwidth: 690px
          :alt: New Advanced Connection Options
 
-   .. step:: Click the :guilabel:`Advanced` tab.
+   .. step:: Click the :guilabel:`Advanced` tab
 
       (Optional) Select a :guilabel:`Read Preference` from the following 
       options:
@@ -114,24 +105,25 @@ Steps
 
    .. step:: Click Connect.
 
+   .. step:: (Optional) Resolve Data Display Issues
+
+      If Compass is having issues displaying data and returning the error
+      message ``Invalid UTF-8 string in BSON document.``, you can set the 
+      ``enableUtf8Validation`` URI option. 
+
+      The following connection string disables UTF8 validation:
+
+      .. code-block:: javascript
+
+          mongodb://localhost:27017/?enableUtf8Validation=false
+
+      .. note::
+
+        You can also disable this option in the 
+        :guilabel:`Advanced Connection Options` by 
+        selecting the key :guilabel:`enableUtf8Validation` and entering 
+        the value ``false``.
+
 .. seealso::
 
    To disconnect from your deployment, see :ref:`<disconnect-tab>`. 
-
-.. _compass-advanced-connection-examples:
-
-Example
--------
-
-The following connection string disables UTF8 validation:
-
-.. code-block:: javascript
-
-    mongodb://localhost:27017/?enableUtf8Validation=false
-
-.. note::
-
-  You can also disable this option in the 
-  :guilabel:`Advanced Connection Options` by 
-  selecting the key :guilabel:`enableUtf8Validation` and entering 
-  the value ``false``.

--- a/source/connect/advanced-connection-options/advanced-connection.txt
+++ b/source/connect/advanced-connection-options/advanced-connection.txt
@@ -106,12 +106,17 @@ Procedure
 
     .. note::
 
-      There are a few connection string parameters which are supported 
-      only by the ``nodejs`` driver. For details on all supported node
-      specific connection string parameters see 
-      `Node Connection Options 
-      <https://www.mongodb.com/docs/drivers/node/current/fundamentals/connection/connection-options/>`__.
+      The ``enableUtf8Validation`` connection string parameter is only 
+      supported by the ``nodejs`` driver and Compass. This option 
+      allows Compass to display collections which have invalid UTF8 
+      data. To set this parameter you can pass set the ``enableUtf8Validation``
+      parameter in the connection string or use the advanced connections 
+      tab in Compass.
 
+      For example:
+
+      ```mongodb://localhost:27017/?enableUtf8Validation=True``
+      
    .. step:: Click Connect.
 
 .. seealso::

--- a/source/connect/advanced-connection-options/advanced-connection.txt
+++ b/source/connect/advanced-connection-options/advanced-connection.txt
@@ -18,19 +18,19 @@ for your deployment. These options can be used with the
 <authentication-connection-tab>`, :ref:`TLS / SSL <tls-ssl-tab>`, and 
 :ref:`Proxy / SSH Tunnel <ssh-connection>` connection options. 
 
-Steps
------
+Procedure
+---------
 
 .. procedure::
    :style: normal
 
-   .. step:: Click :guilabel:`Advanced Connection Options`
+   .. step:: Click :guilabel:`Advanced Connection Options`.
 
       .. figure:: /images/compass/advanced-connection-options.png
          :figwidth: 690px
          :alt: New Advanced Connection Options
 
-   .. step:: Click the :guilabel:`Advanced` tab
+   .. step:: Click the :guilabel:`Advanced` tab.
 
       (Optional) Select a :guilabel:`Read Preference` from the following 
       options:

--- a/source/connect/advanced-connection-options/advanced-connection.txt
+++ b/source/connect/advanced-connection-options/advanced-connection.txt
@@ -22,7 +22,7 @@ for your deployment. These options can be used with the
 About this Task
 ---------------
 
-The ``enableUtf8Validation`` URI option is supported Compass. This 
+The ``enableUtf8Validation`` URI option is supported by Compass. This 
 option allows Compass to display collections that have invalid UTF8 
 data. For details, see 
 :ref:`disabling UTF-8 Validation<compass-advanced-connection-examples>`.

--- a/source/includes/fact-non-utf8-data.rst
+++ b/source/includes/fact-non-utf8-data.rst
@@ -3,17 +3,17 @@ the collection have invalid UTF8 characters.
 
 - If you query this data, the following error message displays: 
 
-.. code-block:: none
+  .. code-block:: none
 
-   Invalid UTF-8 string in BSON document. 
+     Invalid UTF-8 string in BSON document. 
 
 - If you attempt to export the collection, the following error message 
   displays: 
 
-.. code-block:: none
+  .. code-block:: none
 
-   An error occurred while loading instance info: Invalid UTF-8 
-   string in BSON document.
+     An error occurred while loading instance info: Invalid UTF-8 
+     string in BSON document.
 
 You can disable UTF8 validation by setting the ``enableUtf8Validation`` 
 URI option to ``false``. 

--- a/source/includes/fact-non-utf8-data.rst
+++ b/source/includes/fact-non-utf8-data.rst
@@ -3,16 +3,24 @@ the collection have invalid UTF8 characters.
 
 - If you query this data, the following error message displays: 
 
-.. warning:: 
+  .. warning:: 
 
       Invalid UTF-8 string in BSON document. 
 
 - If you attempt to export the collection, the error message: 
 
   .. warning:: 
-      
-      An error occurred while loading instance info: Invalid UTF-8 
-      string in BSON document.
+
+      .. code-block:: none
+
+            An error occurred while loading instance info: Invalid UTF-8 
+            string in BSON document.
+
+.. error:: 10167
+
+   :message: "can't move shard to its current location!"
+   :throws: UserException
+   :module: :source:`src/mongo/s/chunk.cpp#L305`
 
 You can disable UTF8 validation by setting the ``enableUtf8Validation`` 
 URI option to ``false``. 

--- a/source/includes/fact-non-utf8-data.rst
+++ b/source/includes/fact-non-utf8-data.rst
@@ -15,7 +15,7 @@ UTF8 validation by setting the ``enableUtf8Validation`` URI option to
 
 .. warning::
 
-   *Editing data* with ``enableUtf8Validation=false`` can result in 
+   **Editing data** with ``enableUtf8Validation=false`` can result in 
    potential loss of data. This approach should be used as a temporary 
    workaround to query or export data only.
 

--- a/source/includes/fact-non-utf8-data.rst
+++ b/source/includes/fact-non-utf8-data.rst
@@ -29,6 +29,6 @@ The following URI disables UTF8 validation:
 .. note::
 
    You can also disable this option in the 
-   :guilabel:`Advanced Connection Options` by 
+   :ref:`Advanced Connection Options <advanced-connection-tab>` by 
    selecting the key :guilabel:`enableUtf8Validation` and entering 
    the value ``false``.

--- a/source/includes/fact-non-utf8-data.rst
+++ b/source/includes/fact-non-utf8-data.rst
@@ -30,5 +30,5 @@ The following URI disables UTF8 validation:
 
    You can also disable this option in the 
    :ref:`Advanced Connection Options <advanced-connection-tab>` by 
-   selecting the key :guilabel:`enableUtf8Validation` and entering 
-   the value ``false``.
+   selecting :guilabel:`enableUtf8Validation` and entering 
+   ``false``.

--- a/source/includes/fact-non-utf8-data.rst
+++ b/source/includes/fact-non-utf8-data.rst
@@ -1,6 +1,20 @@
-If Compass encounters data display issues when querying your data 
-with the error message: ``Invalid UTF-8 string in BSON document``. You 
-can disable UTF8 validation by setting the ``enableUtf8Validation`` 
+Compass can have issues displaying collections if documents within
+the collection have invalid UTF8 characters.
+
+- If you query this data, the following error message displays: 
+
+.. warning:: 
+
+      Invalid UTF-8 string in BSON document. 
+
+- If you attempt to export the collection, the error message: 
+
+  .. warning:: 
+      
+      An error occurred while loading instance info: Invalid UTF-8 
+      string in BSON document.
+
+You can disable UTF8 validation by setting the ``enableUtf8Validation`` 
 URI option to ``false``. 
 
 The following URI disables UTF8 validation:

--- a/source/includes/fact-non-utf8-data.rst
+++ b/source/includes/fact-non-utf8-data.rst
@@ -19,6 +19,12 @@ The following URI disables UTF8 validation:
 
       mongodb://localhost:27017/?enableUtf8Validation=false
 
+.. warning::
+
+   Editing data with ``enableUtf8Validation=false`` can result in 
+   potential loss of data. This approach should be used as a temporary 
+   workaround only.
+
 .. note::
 
    You can also disable this option in the 

--- a/source/includes/fact-non-utf8-data.rst
+++ b/source/includes/fact-non-utf8-data.rst
@@ -3,24 +3,17 @@ the collection have invalid UTF8 characters.
 
 - If you query this data, the following error message displays: 
 
-  .. warning:: 
+.. code-block:: none
 
-      Invalid UTF-8 string in BSON document. 
+   Invalid UTF-8 string in BSON document. 
 
-- If you attempt to export the collection, the error message: 
+- If you attempt to export the collection, the following error message 
+  displays: 
 
-  .. warning:: 
+.. code-block:: none
 
-      .. code-block:: none
-
-            An error occurred while loading instance info: Invalid UTF-8 
-            string in BSON document.
-
-.. error:: 10167
-
-   :message: "can't move shard to its current location!"
-   :throws: UserException
-   :module: :source:`src/mongo/s/chunk.cpp#L305`
+   An error occurred while loading instance info: Invalid UTF-8 
+   string in BSON document.
 
 You can disable UTF8 validation by setting the ``enableUtf8Validation`` 
 URI option to ``false``. 

--- a/source/includes/fact-non-utf8-data.rst
+++ b/source/includes/fact-non-utf8-data.rst
@@ -2,8 +2,7 @@ If Compass is having issues displaying data and returning the error
 message: ``Invalid UTF-8 string in BSON document``, you can set the 
 ``enableUtf8Validation`` URI option to ``false``. 
 
-The following connection string disables UTF8 validation with the URI 
-parameter:
+The following URI disables UTF8 validation:
 
 .. code-block:: javascript
 

--- a/source/includes/fact-non-utf8-data.rst
+++ b/source/includes/fact-non-utf8-data.rst
@@ -1,7 +1,7 @@
 If Compass encounters data display issues when querying your data 
 with the error message: ``Invalid UTF-8 string in BSON document``. You 
 can disable UTF8 validation by setting the ``enableUtf8Validation`` 
-URI option to false. 
+URI option to ``false``. 
 
 The following URI disables UTF8 validation:
 

--- a/source/includes/fact-non-utf8-data.rst
+++ b/source/includes/fact-non-utf8-data.rst
@@ -1,0 +1,17 @@
+If Compass is having issues displaying data and returning the error
+message: ``Invalid UTF-8 string in BSON document``, you can set the 
+``enableUtf8Validation`` URI option to ``false``. 
+
+The following connection string disables UTF8 validation with the URI 
+parameter:
+
+.. code-block:: javascript
+
+      mongodb://localhost:27017/?enableUtf8Validation=false
+
+.. note::
+
+   You can also disable this option in the 
+   :guilabel:`Advanced Connection Options` by 
+   selecting the key :guilabel:`enableUtf8Validation` and entering 
+   the value ``false``.

--- a/source/includes/fact-non-utf8-data.rst
+++ b/source/includes/fact-non-utf8-data.rst
@@ -1,22 +1,18 @@
-Compass can have issues displaying collections if documents have 
-invalid UTF8 characters.
-
-If you attempt to query or export this data, the following error 
-message displays: 
+If you attempt to query or export data with invalid UTF8 characters
+the following error message displays: 
 
 .. code-block:: none
    :copyable: false
 
    Invalid UTF-8 string in BSON document. 
 
-In order to query or export this data, you can disable 
-UTF8 validation by setting the ``enableUtf8Validation`` URI option to 
-``false``. 
+To query or export this data, disable UTF8 validation by setting 
+the ``enableUtf8Validation`` URI option to ``false``. 
 
 .. warning::
 
    **Editing data** with ``enableUtf8Validation=false`` can result in 
-   potential loss of data. This approach is a temporary workaround to 
+   loss of data. This approach is a temporary workaround to 
    query or export data only.
 
 The following URI disables UTF8 validation:

--- a/source/includes/fact-non-utf8-data.rst
+++ b/source/includes/fact-non-utf8-data.rst
@@ -1,6 +1,7 @@
-If Compass is having issues displaying data and returning the error
-message: ``Invalid UTF-8 string in BSON document``, you can set the 
-``enableUtf8Validation`` URI option to ``false``. 
+If Compass encounters data display issues when querying your data 
+with the error message: ``Invalid UTF-8 string in BSON document``. You 
+can disable UTF8 validation by setting the ``enableUtf8Validation`` 
+URI option to false. 
 
 The following URI disables UTF8 validation:
 

--- a/source/includes/fact-non-utf8-data.rst
+++ b/source/includes/fact-non-utf8-data.rst
@@ -1,22 +1,17 @@
 Compass can have issues displaying collections if documents within
 the collection have invalid UTF8 characters.
 
-- If you query this data, the following error message displays: 
+If you attemp to query or export this data, the following error 
+message displays: 
 
-  .. code-block:: none
+.. code-block:: none
+   :copyable: false
 
-     Invalid UTF-8 string in BSON document. 
+   Invalid UTF-8 string in BSON document. 
 
-- If you attempt to export the collection, the following error message 
-  displays: 
-
-  .. code-block:: none
-
-     An error occurred while loading instance info: Invalid UTF-8 
-     string in BSON document.
-
-You can disable UTF8 validation by setting the ``enableUtf8Validation`` 
-URI option to ``false``. 
+In order to query or export this data, you can disable 
+UTF8 validation by setting the ``enableUtf8Validation`` URI option to 
+``false``. 
 
 The following URI disables UTF8 validation:
 

--- a/source/includes/fact-non-utf8-data.rst
+++ b/source/includes/fact-non-utf8-data.rst
@@ -15,9 +15,9 @@ UTF8 validation by setting the ``enableUtf8Validation`` URI option to
 
 .. warning::
 
-   Editing data with ``enableUtf8Validation=false`` can result in 
+   *Editing data* with ``enableUtf8Validation=false`` can result in 
    potential loss of data. This approach should be used as a temporary 
-   workaround to query and export data only.
+   workaround to query or export data only.
 
 The following URI disables UTF8 validation:
 

--- a/source/includes/fact-non-utf8-data.rst
+++ b/source/includes/fact-non-utf8-data.rst
@@ -16,8 +16,8 @@ UTF8 validation by setting the ``enableUtf8Validation`` URI option to
 .. warning::
 
    **Editing data** with ``enableUtf8Validation=false`` can result in 
-   potential loss of data. This approach should be used as a temporary 
-   workaround to query or export data only.
+   potential loss of data. This approach is a temporary workaround to 
+   query or export data only.
 
 The following URI disables UTF8 validation:
 

--- a/source/includes/fact-non-utf8-data.rst
+++ b/source/includes/fact-non-utf8-data.rst
@@ -1,7 +1,7 @@
-Compass can have issues displaying collections if documents within
-the collection have invalid UTF8 characters.
+Compass can have issues displaying collections if documents have 
+invalid UTF8 characters.
 
-If you attemp to query or export this data, the following error 
+If you attempt to query or export this data, the following error 
 message displays: 
 
 .. code-block:: none

--- a/source/includes/fact-non-utf8-data.rst
+++ b/source/includes/fact-non-utf8-data.rst
@@ -13,17 +13,18 @@ In order to query or export this data, you can disable
 UTF8 validation by setting the ``enableUtf8Validation`` URI option to 
 ``false``. 
 
+.. warning::
+
+   Editing data with ``enableUtf8Validation=false`` can result in 
+   potential loss of data. This approach should be used as a temporary 
+   workaround to query and export data only.
+
 The following URI disables UTF8 validation:
 
 .. code-block:: javascript
 
       mongodb://localhost:27017/?enableUtf8Validation=false
 
-.. warning::
-
-   Editing data with ``enableUtf8Validation=false`` can result in 
-   potential loss of data. This approach should be used as a temporary 
-   workaround only.
 
 .. note::
 

--- a/source/query/filter.txt
+++ b/source/query/filter.txt
@@ -374,6 +374,7 @@ Clear the Query
 
 .. include:: /includes/clear-query.rst
 
+.. _compass-query-invalid-utf8-data:
 
 Querying Collections with Invalid UTF8 Data
 -------------------------------------------

--- a/source/query/filter.txt
+++ b/source/query/filter.txt
@@ -374,6 +374,12 @@ Clear the Query
 
 .. include:: /includes/clear-query.rst
 
+
+Querying Invalid Collections with UTF8 Data
+-------------------------------------------
+
+.. include:: /includes/fact-non-utf8-data.rst
+
 How Does the Compass Query Compare to MongoDB and SQL Queries?
 --------------------------------------------------------------
 

--- a/source/query/filter.txt
+++ b/source/query/filter.txt
@@ -375,7 +375,7 @@ Clear the Query
 .. include:: /includes/clear-query.rst
 
 
-Querying Invalid Collections with UTF8 Data
+Querying Collections with Invalid UTF8 Data
 -------------------------------------------
 
 .. include:: /includes/fact-non-utf8-data.rst

--- a/source/query/filter.txt
+++ b/source/query/filter.txt
@@ -376,8 +376,8 @@ Clear the Query
 
 .. _compass-query-invalid-utf8-data:
 
-Querying Collections with Invalid UTF8 Data
--------------------------------------------
+Query Collections with Invalid UTF8 Data
+----------------------------------------
 
 .. include:: /includes/fact-non-utf8-data.rst
 


### PR DESCRIPTION
## DESCRIPTION

This edit adds mention to the nodejs / Compass URI option `enableUtf8Validation` which allows Compass to show collections that contain invalid UTF8 data. This additional option needs mention on https://www.mongodb.com/docs/drivers/node/current/fundamentals/connection/connection-options/, it works as [both a client parameter](https://www.mongodb.com/docs/drivers/node/current/fundamentals/bson/utf8-validation/#specify-the-utf-8-validation-setting) and a URI connection string option. 


Parsing logic: https://github.com/mongodb/js-bson/blob/main/src/parser/deserializer.ts#L678. 

## STAGING

https://preview-mongodbianfmongodb.gatsbyjs.io/compass/DOCSP-23996/query/filter/#query-collections-with-invalid-utf8-data

## JIRA

https://jira.mongodb.org/browse/DOCSP-23996

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=654bfb1f5b686d6bd982a45d

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)