### PR TITLE
DOCSP-34660  Infinite Loop Redirects, Missing End Line, Correct URL

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -7,7 +7,9 @@ raw: docs/compass/index.html -> ${base}/current/
 raw: docs/compass/ -> ${base}/current/
 
 [master-beta]: docs/compass/${version}/query-bar -> ${base}/${version}/query/filter/
+[master-beta]: docs/compass/${version}/aggregation-pipeline-builder -> ${base}/current/aggregation-pipeline-builder/
 [*]: docs/compass/${version}/dark-mode/ -> ${base}/current/settings/settings-reference/#settings
 [*]: docs/compass/${version}/config-file/config-file-options/ -> ${base}/current/settings/config-file/
-[*]: docs/compass/${version}/aggregation-pipeline-builder -> ${base}/current/aggregation-pipeline-builder/
 [*]: docs/compass/${version}/query/favorite/ -> ${base}/current/query/queries/
+[*]: docs/compass/${version}/import-pipeline-from-text/ -> ${base}/current/aggregation-pipeline-builder/
+[*]: docs/compass/${version}/export-pipeline-to-language/ -> ${base}/current/agg-pipeline-builder/export-pipeline-to-language/

--- a/config/redirects
+++ b/config/redirects
@@ -7,9 +7,9 @@ raw: docs/compass/index.html -> ${base}/current/
 raw: docs/compass/ -> ${base}/current/
 
 [master-beta]: docs/compass/${version}/query-bar -> ${base}/${version}/query/filter/
-[master-beta]: docs/compass/${version}/aggregation-pipeline-builder -> ${base}/current/aggregation-pipeline-builder/
+[*]: docs/compass/${version}/aggregation-pipeline-builder -> ${base}/current/create-agg-pipeline/
 [*]: docs/compass/${version}/dark-mode/ -> ${base}/current/settings/settings-reference/#settings
 [*]: docs/compass/${version}/config-file/config-file-options/ -> ${base}/current/settings/config-file/
 [*]: docs/compass/${version}/query/favorite/ -> ${base}/current/query/queries/
-[*]: docs/compass/${version}/import-pipeline-from-text/ -> ${base}/current/aggregation-pipeline-builder/
+[*]: docs/compass/${version}/import-pipeline-from-text/ -> ${base}/current/create-agg-pipeline/
 [*]: docs/compass/${version}/export-pipeline-to-language/ -> ${base}/current/agg-pipeline-builder/export-pipeline-to-language/


### PR DESCRIPTION
## DESCRIPTION
Corrects redirect links to the current agg pipeline builder link

## STAGING
N/A but `mut-redirect` output show below in comments

## JIRA
https://jira.mongodb.org/browse/DOCSP-34660

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=656a06bb7a5cb5fef5e8f83c

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)