### PR TITLE
DOCSP-32117 default curly braces in query

### DIFF
--- a/source/query/filter.txt
+++ b/source/query/filter.txt
@@ -40,10 +40,10 @@ Compatibility
 Set Query Filter
 ----------------
 
-#. In the :guilabel:`Filter` field, enter a filter document. You can use
-   all of the MongoDB :manual:`query operators
+#. In the :guilabel:`Filter` field, enter a filter document between the
+   curly braces. You can use all of the MongoDB :manual:`query operators
    </reference/operator/query/>` except the :query:`$text` and
-   :query:`$expr` operators.
+   :query:`$expr` operators. 
 
    .. example::
 

--- a/source/query/filter.txt
+++ b/source/query/filter.txt
@@ -41,7 +41,7 @@ Set Query Filter
 ----------------
 
 #. In the :guilabel:`Filter` field, enter a filter document between the
-   curly braces. You can use all of the MongoDB :manual:`query operators
+   curly braces. You can use all the MongoDB :manual:`query operators
    </reference/operator/query/>` except the :query:`$text` and
    :query:`$expr` operators.
 

--- a/source/query/filter.txt
+++ b/source/query/filter.txt
@@ -43,7 +43,7 @@ Set Query Filter
 #. In the :guilabel:`Filter` field, enter a filter document between the
    curly braces. You can use all of the MongoDB :manual:`query operators
    </reference/operator/query/>` except the :query:`$text` and
-   :query:`$expr` operators. 
+   :query:`$expr` operators.
 
    .. example::
 


### PR DESCRIPTION
## DESCRIPTION

Compass automatically adds curly braces to filter input text

## STAGING

https://preview-mongodbltranmdb2.gatsbyjs.io/compass/DOCSP-32117/query/filter/

## JIRA

https://jira.mongodb.org/browse/DOCSP-32117

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=659d833bdcc0144a518df554

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)