### PR TITLE
DOCSP 27810 updating schema validation behavior 

### DIFF
--- a/source/validation.txt
+++ b/source/validation.txt
@@ -35,14 +35,14 @@ specific shape or only allowing a specified range of values in fields.
 Validation Rules
 ----------------
 
-*Updated in version 1.18.*
+*Updated in version 1.35.1*
 
 The validation editor supports :manual:`JSON Schema validation
 </core/schema-validation/#json-schema>`, and validation with query
-expressions using :manual:`query operators
-</reference/operator/query>`. As you edit your validation,
-|compass-short| updates in real-time to display a document from your
-collection that passes the validation and a document that fails.
+expressions using :manual:`query operators </reference/operator/query>`.
+When you hit the Update button, Compass updates to display a document
+from your collection that passes the validation and a document that
+fails.
 
 JSON Schema Validation
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/source/validation.txt
+++ b/source/validation.txt
@@ -40,9 +40,9 @@ Validation Rules
 The validation editor supports :manual:`JSON Schema validation
 </core/schema-validation/#json-schema>`, and validation with query
 expressions using :manual:`query operators </reference/operator/query>`.
-When you hit the Update button, Compass updates to display a document
-from your collection that passes the validation and a document that
-fails.
+After you click the :guilabel:`Update` button, Compass updates to
+display a document from your collection that passes the validation and a
+document that fails.
 
 JSON Schema Validation
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## DESCRIPTION

schema validation no longer auto updates in Compass

## STAGING

https://docs-mongodbcom-staging.corp.mongodb.com/compass/docsworker-xlarge/DOCSP-27810/validation/#validation-rules

## JIRA

https://jira.mongodb.org/browse/DOCSP-27810

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65a6f1f2dcc0144a51094dfb

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)