### PR TITLE
DOCSP-35718 Query Data '$and' Syntax

### DIFF
--- a/source/query/filter.txt
+++ b/source/query/filter.txt
@@ -151,7 +151,7 @@ contains the value ``75``, and the ``name`` is ``Greg Powell``:
 
 .. code-block:: shell
 
-   { scores: 75, name: "Greg Powell" }
+   { $and: [ { scores: 75, name: "Greg Powell" } ] }
 
 The query returns the following document:
 


### PR DESCRIPTION
## DESCRIPTION
Fixes syntax example in query page to reflect use of `$and` oeprator.

## STAGING
https://preview-mongodbajhuhmdb.gatsbyjs.io/compass/DOCSP-35718-query-data-syntax/query/filter/#match-by-multiple-conditions---and-

## JIRA
https://jira.mongodb.org/browse/DOCSP-35718

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65ae81ef30987d50507ec5bf

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)