### PR TITLE
DOCSP-29957 protectConnectionStringsForNewConnections parameter

### DIFF
--- a/source/includes/fact-protect-connection-strings.rst
+++ b/source/includes/fact-protect-connection-strings.rst
@@ -1,2 +1,3 @@
-Hide credentials in your connection string. Passwords in connection 
-strings are displayed as ``*****``
+Sets all connection strings as read-only and hides the :guilabel:`Edit
+connection string` toggle in the :guilabel:`General` connection tab.
+Passwords in connection strings display as ``*****``.

--- a/source/includes/fact-protect-connection-strings.rst
+++ b/source/includes/fact-protect-connection-strings.rst
@@ -1,3 +1,6 @@
-Sets all connection strings as read-only and hides the :guilabel:`Edit
-connection string` toggle in the :guilabel:`General` connection tab.
-Passwords in connection strings display as ``*****``.
+Sets all connection strings as read-only. Passwords in connection
+strings display as ``*****``.
+
+If ``protectConnctionStrings`` is enabled, |compass-short| disables the
+:guilabel:`Edit connection string` option and hides the 
+:guilabel:`Edit connection string` toggle. 

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -109,17 +109,14 @@ Settings
      - .. include:: /includes/fact-protect-connection-strings.rst 
 
    * - protectConnectionStringsForNewConnections
-     - Sets connection strings for new connections as read-only and
-       disables the :guilabel:`Edit connection string` option. Passwords
-       in connection strings display as ``*****``.
+     - Sets connection strings for new connections as read-only. Passwords
+       in new connection strings display as ``*****``.
+     
+       If ``protectConnctionStrings`` is enabled, |compass-short| disables the
+       :guilabel:`Edit connection string` option but does not prevent
+       users from manually enabling the option.
 
        *Default:* false
-
-       .. note:: 
-
-          Configuring the ``protectConnectionStringsForNewConnections``
-          setting doesn't prevent users from manually enabling the
-          :guilabel:`Edit connection string` option. 
 
    * - :ref:`readOnly <compass-read-only>`
      - Prevent users from performing write operations to your MongoDB deployment 

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -117,8 +117,6 @@ Settings
        option but doesn't prevent users from manually enabling the
        option with the :guilabel:`Edit connection string` toggle. 
 
-       *Default:* false
-
    * - :ref:`readOnly <compass-read-only>`
      - Prevent users from performing write operations to your MongoDB deployment 
        through |compass-short|.

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -109,15 +109,19 @@ Settings
      - .. include:: /includes/fact-protect-connection-strings.rst 
 
    * - protectConnectionStringsForNewConnections
-     - Specifies whether the :guilabel:`Edit connection string` option
-       in the :guilabel:`General` connection tab is automatically on or off for new
-       connections.
+     - Hides credentials in your connection string for new connections. 
 
        *Default:* false
 
-       If ``protectConnectionStringsForNewConnections`` is true, the
-       default state of the :guilabel:`Edit connection string` option is
-       off for new connections. 
+       If ``protectConnectionStringsForNewConnections`` is ``true``,
+       the default state of the :guilabel:`Edit connection string`
+       option is off for new connections.
+
+       .. note:: 
+
+          ``protectConnectionStringsForNewConnections`` does not prevent
+          users from manually toggling the :guilabel:`Edit connection
+          string` on or off. 
 
    * - :ref:`readOnly <compass-read-only>`
      - Prevent users from performing write operations to your MongoDB deployment 

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -109,14 +109,15 @@ Settings
      - .. include:: /includes/fact-protect-connection-strings.rst 
 
    * - protectConnectionStringsForNewConnections
-     - Hides credentials in your connection string for new connections. 
+     - Sets connection strings for new connections as read-only and
+       disables the :guilabel:`Edit connection string` option. Passwords
+       in connection strings display as ``*****``.
 
        *Default:* false
 
-       If ``protectConnectionStringsForNewConnections`` is ``true``,
-       the default state of the :guilabel:`Edit connection string`
-       option in the :guilabel:`General` connection tab is off for new
-       connections.
+       Configuring the ``protectConnectionStringsForNewConnections``
+       setting doesn't prevent users from manually enabling the
+       :guilabel:`Edit connection string` option. 
 
        .. note:: 
 

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -108,6 +108,17 @@ Settings
    * - :ref:`protectConnectionStrings <compass-protect-connection-strings>`
      - .. include:: /includes/fact-protect-connection-strings.rst 
 
+   * - protectConnectionStringsForNewConnections
+     - Specifies whether the :guilabel:`Edit connection string` option
+       in the :guilabel:`General` connection tab is automatically on or off for new
+       connections.
+
+       *Default:* false
+
+       If ``protectConnectionStringsForNewConnections`` is true, the
+       default state of the guilabel:`Edit connection string` option is
+       off for new connections. 
+
    * - :ref:`readOnly <compass-read-only>`
      - Prevent users from performing write operations to your MongoDB deployment 
        through |compass-short|.

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -121,8 +121,8 @@ Settings
        .. note:: 
 
           Configuring the ``protectConnectionStringsForNewConnections``
-          setting does not prevent users from manually toggling the
-          :guilabel:`Edit connection string` option on or off. 
+          setting doesn't prevent users from manually enabling the
+          :guilabel:`Edit connection string` option. 
 
    * - :ref:`readOnly <compass-read-only>`
      - Prevent users from performing write operations to your MongoDB deployment 

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -115,7 +115,7 @@ Settings
        If ``protectConnctionStringsForNewConnections`` is enabled,
        |compass-short| disables the :guilabel:`Edit connection string`
        option but doesn't prevent users from manually enabling the
-       option.
+       option with the :guilabel:`Edit connection string`toggle. 
 
        *Default:* false
 

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -115,10 +115,6 @@ Settings
 
        *Default:* false
 
-       Configuring the ``protectConnectionStringsForNewConnections``
-       setting doesn't prevent users from manually enabling the
-       :guilabel:`Edit connection string` option. 
-
        .. note:: 
 
           Configuring the ``protectConnectionStringsForNewConnections``

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -115,7 +115,7 @@ Settings
        If ``protectConnctionStringsForNewConnections`` is enabled,
        |compass-short| disables the :guilabel:`Edit connection string`
        option but doesn't prevent users from manually enabling the
-       option with the :guilabel:`Edit connection string`toggle. 
+       option with the :guilabel:`Edit connection string` toggle. 
 
        *Default:* false
 

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -116,7 +116,7 @@ Settings
        *Default:* false
 
        If ``protectConnectionStringsForNewConnections`` is true, the
-       default state of the guilabel:`Edit connection string` option is
+       default state of the :guilabel:`Edit connection string` option is
        off for new connections. 
 
    * - :ref:`readOnly <compass-read-only>`

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -109,8 +109,9 @@ Settings
      - .. include:: /includes/fact-protect-connection-strings.rst 
 
    * - protectConnectionStringsForNewConnections
-     - Sets connection strings for new connections as read-only. Passwords
-       in new connection strings display as ``*****``.
+     - Sets connection strings for new connections as read-only by
+       default. Passwords in new connection strings display as
+       ``*****``.
      
        If ``protectConnctionStringsForNewConnections`` is enabled,
        |compass-short| disables the :guilabel:`Edit connection string`

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -112,9 +112,10 @@ Settings
      - Sets connection strings for new connections as read-only. Passwords
        in new connection strings display as ``*****``.
      
-       If ``protectConnctionStrings`` is enabled, |compass-short| disables the
-       :guilabel:`Edit connection string` option but does not prevent
-       users from manually enabling the option.
+       If ``protectConnctionStringsForNewConnections`` is enabled,
+       |compass-short| disables the :guilabel:`Edit connection string`
+       option but doesn't prevent users from manually enabling the
+       option.
 
        *Default:* false
 

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -115,13 +115,14 @@ Settings
 
        If ``protectConnectionStringsForNewConnections`` is ``true``,
        the default state of the :guilabel:`Edit connection string`
-       option is off for new connections.
+       option in the :guilabel:`General` connection tab is off for new
+       connections.
 
        .. note:: 
 
-          ``protectConnectionStringsForNewConnections`` does not prevent
-          users from manually toggling the :guilabel:`Edit connection
-          string` on or off. 
+          Configuring the ``protectConnectionStringsForNewConnections``
+          setting does not prevent users from manually toggling the
+          :guilabel:`Edit connection string` option on or off. 
 
    * - :ref:`readOnly <compass-read-only>`
      - Prevent users from performing write operations to your MongoDB deployment 


### PR DESCRIPTION
## DESCRIPTION

documenting new global config property `protectConnectionStringsForNewConnections`

## STAGING

https://preview-mongodbltranmdb2.gatsbyjs.io/compass/DOCSP-29957/settings/config-file/#settings

## JIRA

https://jira.mongodb.org/browse/DOCSP-29957

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65c10d026b2f17c95afaf410

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)