### PR TITLE
DOCSP-35111 Reorganize release notes order

### DIFF
--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -10,6 +10,32 @@ Release Notes
    :depth: 1
    :class: twocols
 
+|compass| 1.42.0
+----------------
+
+*Released January 31, 2024*
+
+New Features
+
+- Compass now supports :ref:`Bulk Update <compass-bulk-update>` and 
+  :ref:`Bulk Delete<compass-bulk-delete>`
+  operations (:issue:`COMPASS-7329`, :issue:`COMPASS-7330`).
+
+Bug Fixes
+
+- Fixed namespace stats that refresh after document updates.
+- Fixed table card autosizing (:issue:`COMPASS-7548`).
+- Fixed an issue when opening a new collection tab if an existing 
+  collection tab with the same name was already open 
+  (:issue:`COMPASS-7556`).
+- Fixed an issue where switching tabs would reset vertical scrolling 
+  to the top position (:issue:`COMPASS-7370`).
+- Fixed an issue where invalid dates resulted in a blank export page 
+  (:issue:`COMPASS-7515`).
+
+`Full changelog available on GitHub
+<https://github.com/mongodb-js/compass/compare/v1.41.0...v1.42.0>`__
+
 |compass| 1.41.0
 ----------------
 
@@ -50,32 +76,6 @@ Bug Fixes:
 
 `Full changelog available on GitHub
 <https://github.com/mongodb-js/compass/compare/v1.40.4...v1.41.0>`__
-
-|compass| 1.42.0
-----------------
-
-*Released January 31, 2024*
-
-New Features
-
-- Compass now supports :ref:`Bulk Update <compass-bulk-update>` and 
-  :ref:`Bulk Delete<compass-bulk-delete>`
-  operations (:issue:`COMPASS-7329`, :issue:`COMPASS-7330`).
-
-Bug Fixes
-
-- Fixed namespace stats that refresh after document updates.
-- Fixed table card autosizing (:issue:`COMPASS-7548`).
-- Fixed an issue when opening a new collection tab if an existing 
-  collection tab with the same name was already open 
-  (:issue:`COMPASS-7556`).
-- Fixed an issue where switching tabs would reset vertical scrolling 
-  to the top position (:issue:`COMPASS-7370`).
-- Fixed an issue where invalid dates resulted in a blank export page 
-  (:issue:`COMPASS-7515`).
-
-`Full changelog available on GitHub
-<https://github.com/mongodb-js/compass/compare/v1.41.0...v1.42.0>`__
 
 |compass| 1.40.4
 ----------------


### PR DESCRIPTION
## DESCRIPTION

Somehow when merging #591  1.41.0 release notes got put higher on the page than the latest release 1.42.0 release notes. This is a quick fix to remedy the release notes ordering.

## STAGING

https://preview-mongodbianfmongodb.gatsbyjs.io/compass/DOCSP-35111-b/

## JIRA

https://jira.mongodb.org/browse/DOCSP-35111

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65c238f86b2f17c95a5172ff

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)