### PR TITLE
DOCSP-29775 document add button to open settings to sidebar

### DIFF
--- a/source/settings/settings-reference.txt
+++ b/source/settings/settings-reference.txt
@@ -30,6 +30,12 @@ To find the |compass-short| :guilabel:`Settings` panel, open the
   :scale: 60%
   :alt: Settings panel location under the MongoDB Compass system menu
 
+You can also open the the |compass-short| :guilabel:`Settings` panel
+when connected to your cluster by doing the following: 
+
+1. Click the :icon-fa5:`ellipsis-h` next to your cluster name.
+2. Select :guilabel:`Compass Settings` from the dropdown.
+
 Alternatively, you can use keyboard shortcuts to open the :guilabel:`Settings` 
 panel: 
 


### PR DESCRIPTION
## DESCRIPTION
Document new buttons in the UI to access Compass' settings.

## STAGING
https://preview-mongodbkanchanamongodb.gatsbyjs.io/compass/DOCSP-29775/settings/settings-reference/#settings-panel-location

## JIRA
https://jira.mongodb.org/browse/DOCSP-29775

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65ccfdcacbcd269fa534ef15

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)