### PR TITLE
DOCSP-28027 document Time series option UI changes

### DIFF
--- a/source/collections/capped-collection.txt
+++ b/source/collections/capped-collection.txt
@@ -29,7 +29,7 @@ Procedure
 
    .. step:: Enter the collection name.
 
-   .. step:: Click the :guilabel:`Advanced Collection Options` dropdown.
+   .. step:: Click the :guilabel:`Additional preferences` dropdown.
 
       Check the :guilabel:`Capped Collection` option.
 

--- a/source/collections/capped-collection.txt
+++ b/source/collections/capped-collection.txt
@@ -16,28 +16,28 @@ Create a Capped Collection
 collections that support high-throughput operations that insert and retrieve 
 documents based on insertion order. 
 
-Procedure
----------
+Steps
+-----
 
 .. procedure::
    :style: connected
 
-   .. step:: Click the :guilabel:`Create Collection` button.
+   .. step:: Click the :guilabel:`Create Collection` button
 
       From the :guilabel:`Collections` screen, click the 
       :guilabel:`Create Collection` button.
 
-   .. step:: Enter the collection name.
+   .. step:: Enter the collection name
 
-   .. step:: Click the :guilabel:`Additional preferences` dropdown.
+   .. step:: Click the :guilabel:`Additional preferences` dropdown
 
       Check the :guilabel:`Capped Collection` option.
 
-   .. step:: Enter the :guilabel:`size` of the capped collection.
+   .. step:: Enter the :guilabel:`size` of the capped collection
 
       Enter the maximum number of bytes that the collection can hold.
 
-   .. step:: Click :guilabel:`Create Collection` to create the collection.
+   .. step:: Click :guilabel:`Create Collection` to create the collection
 
 Restrictions and Limitations
 ----------------------------

--- a/source/collections/clustered-collection.txt
+++ b/source/collections/clustered-collection.txt
@@ -48,7 +48,7 @@ Steps
 
    .. step:: Select the type of collection you want to create.
 
-      From the :guilabel:`Advanced Collection Options` drop-down, select 
+      From the :guilabel:`Additional preferences` drop-down, select 
       :guilabel:`Clustered Collections`.
 
    .. step:: (Optional) Name your clustered index.

--- a/source/collections/collation-collection.txt
+++ b/source/collections/collation-collection.txt
@@ -29,7 +29,7 @@ Procedure
 
    .. step:: Enter the collection name.
 
-   .. step:: Click the :guilabel:`Advanced Collection Options` dropdown.
+   .. step:: Click the :guilabel:`Additional preferences` dropdown.
 
       Check the :guilabel:`Use Custom Collaton` option.
 

--- a/source/collections/encrypted-collection.txt
+++ b/source/collections/encrypted-collection.txt
@@ -28,7 +28,7 @@ Procedure
 
    .. step:: Enter the collection name.
 
-   .. step:: Click the :guilabel:`Advanced Collection Options` dropdown.
+   .. step:: Click the :guilabel:`Additional preferences` dropdown.
 
       Check the :guilabel:`Queryable Encryption` option.
 

--- a/source/collections/time-series-collection.txt
+++ b/source/collections/time-series-collection.txt
@@ -28,70 +28,66 @@ Procedure
 
    .. step:: Enter the collection name.
 
-   .. step:: Click the :guilabel:`Advanced Collection Options` dropdown.
-
-      Check the :guilabel:`Time Series Collection` option.
+   .. step:: Check the :guilabel:`Time Series Collection` option.
 
    .. step:: Specify a :guilabel:`timeField`.
 
       Specify which field should be used as the ``timeField`` for the time-series 
       collection. This field must have a :manual:`BSON type date </reference/bson-types/>`.
 
-      The following fields are optional:
+   .. step:: *Optional*. Specify a :guilabel:`metaField`.
 
-      .. list-table::
+      Specify the name of the field that contains metadata in each time
+      series document. The metadata in the specified field should be
+      data that is used to label a unique series of documents. 
+
+   .. step:: *Optional*. Select a :guilabel:`granularity` from the dropdown.
+
+      Specify a coarser granularity so measurements over a longer time
+      span can be more efficiently stored and queried. The default value
+      is ``"seconds"``. 
+
+      If you set the ``granularity`` parameter, you can't set the
+      ``bucketMaxSpanSeconds`` and ``bucketRoundingSeconds`` parameters. 
+
+   .. step:: *Optional*. Specify a numeric value for the following fields.
+
+      .. list-table:: 
+         :widths: 20 10 70
          :header-rows: 1
-         :widths: 20 20 60
 
-         * - Field
-           - Type
-           - Description 
-
-         * - ``metaField``
-           - string
-           - The name of the field that contains metadata in each time series 
-             document. The metadata in the specified field should be data that 
-             is used to label a unique series of documents. 
-
-         * - ``granularity``
-           - string 
-           - Specifies a coarser granularity so measurements over a 
-             longer time span can be more efficiently stored and queried.
-
-             The default value is ``"seconds"``.
-
-             If you set the ``granularity`` parameter, you can't set the 
-             ``bucketMaxSpanSeconds`` and ``bucketRoundingSeconds`` parameters.
-
-         * - ``expireAfterSeconds``
-           - number
-           -  Enables the automatic deletion of documents that are older than 
-              the specified number of seconds.  
+         * - Field 
+           - Type 
+           - Description
          
          * - ``bucketMaxSpanSeconds``
            - number
-           -  Specifies the maximum time span between measurements in a bucket. 
+           - Specifies the maximum time span between measurements in a bucket. 
 
-              The value of ``bucketMaxSpanSeconds`` must be the same as 
-              ``bucketRoundingSeconds``. If you set the ``bucketMaxSpanSeconds``, 
-              parameter, you can't set the ``granularity`` parameter.
+             The value of ``bucketMaxSpanSeconds`` must be the same as 
+             ``bucketRoundingSeconds``. If you set the ``bucketMaxSpanSeconds``, 
+             parameter, you can't set the ``granularity`` parameter.
 
          * - ``bucketRoundingSeconds``
            - number
-           -  Specifies the time interval that determines the starting timestamp 
-              for a new bucket. 
+           - Specifies the time interval that determines the starting timestamp 
+             for a new bucket. 
 
-              The value of ``bucketRoundingSeconds`` must be the same as 
-              ``bucketMaxSpanSeconds``. If you set the ``bucketRoundingSeconds``, 
-              parameter, you can't set the ``granularity`` parameter.
+             The value of ``bucketRoundingSeconds`` must be the same as 
+             ``bucketMaxSpanSeconds``. If you set the ``bucketRoundingSeconds``, 
+             parameter, you can't set the ``granularity`` parameter.
 
-      For more information on time series fields, see 
-      :manual:`Time Series Object Fields 
-      </core/timeseries/timeseries-procedures/#timeseries-object-fields>`.
+         * - ``expireAfterSeconds``
+           - number
+           - Enables the automatic deletion of documents that are older than 
+             the specified number of seconds.  
 
    .. step:: Click :guilabel:`Create Collection` to create the collection.
 
       Your collection will be marked by a :guilabel:`time series` badge.
+
+For more information on time series fields, see :manual:`Time Series
+Object Fields </core/timeseries/timeseries-procedures/#timeseries-object-fields>`.  
 
 Restrictions and Limitations
 ----------------------------

--- a/source/in-use-encryption-tutorial.txt
+++ b/source/in-use-encryption-tutorial.txt
@@ -62,7 +62,7 @@ Procedure
 
       Enter the name of the database and/or collection.
 
-   .. step:: Click the :guilabel:`Advanced Collection Options` drop down. 
+   .. step:: Click the :guilabel:`Additional preferences` drop down. 
 
    .. step:: Check the :guilabel:`{+qe+}` box.
 

--- a/source/includes/steps-create-collection.yaml
+++ b/source/includes/steps-create-collection.yaml
@@ -12,7 +12,7 @@ content: |
    In the :guilabel:`Create Collection` dialog, enter the name of the
    collection to create.
 
-   |compass-short| also provides you with :guilabel:`Advanced Collection Options`. 
+   |compass-short| also provides you with :guilabel:`Additional preferences`. 
    You can select from the following:
 
    - :ref:`Create a Capped Collection <capped-collection>`


### PR DESCRIPTION
## DESCRIPTION
Documents that Time Series checkbox and all the options that it supports are now right underneath the name of the collection. Also replaces GUI label **Advanced Collection Options** to **Additional Preferences** across pages.

## STAGING
https://preview-mongodbkanchanamongodb.gatsbyjs.io/compass/DOCSP-28027/collections/time-series-collection/

## JIRA
https://jira.mongodb.org/browse/DOCSP-28027

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65cfcfb67111165982695a33

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)