### PR TITLE
DOCSP-37108 Add Compass AI and Data Usage Info Page

### DIFF
--- a/source/query-with-natural-language/ai-and-data-usage-information.txt
+++ b/source/query-with-natural-language/ai-and-data-usage-information.txt
@@ -9,10 +9,10 @@ AI and Data Usage Information
    :backlinks: none
    :depth: 1
 
-Querying with natural language in Compass is powered by generative AI, 
-and may give inaccurate responses. Please see our `Generative AI FAQ 
+Querying with natural language in Compass is powered by Generative AI
+(Gen AI), and may give inaccurate responses. Please see our `Generative AI FAQ 
 <https://dochub.mongodb.org/core/faq-ai-features>`__ 
-for more information about AI in MongoDB products.
+for more information about Gen AI in MongoDB products.
 
 Third Party Providers
 ---------------------
@@ -25,7 +25,7 @@ How Your Data is Used
 ---------------------
 
 When you query with natural language in Compass, the schema of the 
-collection you are querying including collection name, field names, 
+collection you are querying including the collection name, field names, 
 and types. 
 
 The information that is sent is not shared with any other third 
@@ -36,8 +36,9 @@ Disable Natural Language Querying
 ---------------------------------
 
 Natural language querying in Compass is available if you have 
-enabled the Compass :guilabel:`Use Generative AI` setting and logged 
+enabled the :ref:`Compass Use Generative AI setting 
+<enable-natural-language-querying>` and logged 
 into Atlas. If you no longer want to use the feature, you can ignore it 
 and no data will be sent to generative AI models. If you would like to 
-prevent usage of this feature entirely, you can turn it off in 
-Compass :ref:`global configuration file <config-file>`.
+prevent usage of this feature entirely, you can disable it in 
+the :ref:`global configuration file <config-file>`.

--- a/source/query-with-natural-language/ai-and-data-usage-information.txt
+++ b/source/query-with-natural-language/ai-and-data-usage-information.txt
@@ -39,6 +39,6 @@ Natural language querying in Compass is available if you have
 enabled the :ref:`Compass Use Generative AI setting 
 <enable-natural-language-querying>` and logged 
 into Atlas. If you no longer want to use the feature, you can ignore it 
-and no data will be sent to generative AI models. If you would like to 
-prevent usage of this feature entirely, you can disable it in 
-the :ref:`global configuration file <config-file>`.
+and no data will be sent to generative AI models. To prevent usage of 
+this feature entirely, you can disable it in the 
+:ref:`global configuration file <config-file>`.

--- a/source/query-with-natural-language/ai-and-data-usage-information.txt
+++ b/source/query-with-natural-language/ai-and-data-usage-information.txt
@@ -25,7 +25,7 @@ How Your Data is Used
 ---------------------
 
 When you query with natural language in Compass, the following information is sent to MongoDB’s backend and/or the third party AI provider:
-* The schema of the collection you are querying (including collection name, field names, and types). 
+The schema of the collection you are querying (including collection name, field names, and types). 
 
 The information that is sent will not be shared with any other third parties or stored by the AI provider. We do not send database connection strings, credentials, or rows/documents from your databases. 
 

--- a/source/query-with-natural-language/ai-and-data-usage-information.txt
+++ b/source/query-with-natural-language/ai-and-data-usage-information.txt
@@ -17,7 +17,7 @@ for more information about Gen AI in MongoDB products.
 Third Party Providers
 ---------------------
 
-This feature currently uses the `Azure OpenAI Service
+Querying with natural language in Compass currently uses the `Azure OpenAI Service
 <https://azure.microsoft.com/en-us/products/ai-services/openai-service>`__ 
 hosted by Microsoft.  This is subject to change in the future. 
 

--- a/source/query-with-natural-language/ai-and-data-usage-information.txt
+++ b/source/query-with-natural-language/ai-and-data-usage-information.txt
@@ -28,8 +28,8 @@ When you query with natural language in Compass, the following
 information is sent to MongoDB’s backend and/or the third party 
 AI provider: 
 
-- The schema of the collection you are querying 
-  (including collection name, field names, and types). 
+The schema of the collection you are querying 
+(including collection name, field names, and types). 
 
 The information that is sent will not be shared with any other third 
 parties or stored by the AI provider. We do not send database 

--- a/source/query-with-natural-language/ai-and-data-usage-information.txt
+++ b/source/query-with-natural-language/ai-and-data-usage-information.txt
@@ -28,17 +28,17 @@ When you query with natural language in Compass, the schema of the
 collection you are querying including the collection name, field names, 
 and types. 
 
-The information that is sent is not shared with any other third 
-parties or stored by the AI provider. We do not share database 
+The information sent to our AI provider is not shared with any other 
+third parties or stored by the AI provider. We do not share database 
 connection strings, credentials, or raw data from your databases. 
 
 Disable Natural Language Querying
 ---------------------------------
 
-Natural language querying in Compass is available if you have 
-enabled the :ref:`Compass Use Generative AI setting 
-<enable-natural-language-querying>` and logged 
-into Atlas. If you no longer want to use the feature, you can ignore it 
-and no data will be sent to generative AI models. To prevent usage of 
-this feature entirely, you can disable it in the 
-:ref:`global configuration file <config-file>`.
+- Natural language querying in Compass is available if you have 
+  enabled the :ref:`Compass Use Generative AI setting 
+  <enable-natural-language-querying>` and logged into Atlas. 
+- If you no longer want to use the feature, you can ignore it 
+  and no data will be sent to generative AI models. To prevent usage of 
+  this feature entirely, you can disable it in the 
+  :ref:`global configuration file <config-file>`.

--- a/source/query-with-natural-language/ai-and-data-usage-information.txt
+++ b/source/query-with-natural-language/ai-and-data-usage-information.txt
@@ -7,7 +7,7 @@ AI and Data Usage Information
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 2
+   :depth: 1
    :class: singlecol
 
 Querying with natural language in Compass is powered by generative AI, 

--- a/source/query-with-natural-language/ai-and-data-usage-information.txt
+++ b/source/query-with-natural-language/ai-and-data-usage-information.txt
@@ -19,18 +19,15 @@ Third Party Providers
 
 This feature currently uses the `Azure OpenAI Service
 <https://azure.microsoft.com/en-us/products/ai-services/openai-service>`__ 
-hosted by Microsoft. 
+hosted by Microsoft.  This is subject to change in the future. 
 
 How Your Data is Used
 ---------------------
 
-When you query with natural language in Compass, the schema of the 
-collection you are querying including the collection name, field names, 
-and types. 
+When you query with natural language in Compass, the following information is sent to MongoDB’s backend and/or the third party AI provider:
+* The schema of the collection you are querying (including collection name, field names, and types). 
 
-The information sent to our AI provider is not shared with any other 
-third parties or stored by the AI provider. We do not share database 
-connection strings, credentials, or raw data from your databases. 
+The information that is sent will not be shared with any other third parties or stored by the AI provider. We do not send database connection strings, credentials, or rows/documents from your databases. 
 
 Disable Natural Language Querying
 ---------------------------------

--- a/source/query-with-natural-language/ai-and-data-usage-information.txt
+++ b/source/query-with-natural-language/ai-and-data-usage-information.txt
@@ -8,7 +8,6 @@ AI and Data Usage Information
    :local:
    :backlinks: none
    :depth: 1
-   :class: singlecol
 
 Querying with natural language in Compass is powered by generative AI, 
 and may give inaccurate responses. Please see our `Generative AI FAQ 

--- a/source/query-with-natural-language/ai-and-data-usage-information.txt
+++ b/source/query-with-natural-language/ai-and-data-usage-information.txt
@@ -26,8 +26,10 @@ How Your Data is Used
 
 When you query with natural language in Compass, the following 
 information is sent to MongoDB’s backend and/or the third party 
-AI provider: The schema of the collection you are querying 
-(including collection name, field names, and types). 
+AI provider: 
+
+- The schema of the collection you are querying 
+  (including collection name, field names, and types). 
 
 The information that is sent will not be shared with any other third 
 parties or stored by the AI provider. We do not send database 

--- a/source/query-with-natural-language/ai-and-data-usage-information.txt
+++ b/source/query-with-natural-language/ai-and-data-usage-information.txt
@@ -2,7 +2,7 @@
 
 =============================
 AI and Data Usage Information
-==============================
+=============================
 
 .. contents:: On this page
    :local:

--- a/source/query-with-natural-language/ai-and-data-usage-information.txt
+++ b/source/query-with-natural-language/ai-and-data-usage-information.txt
@@ -1,0 +1,44 @@
+.. _compass-ai-data-usage:
+
+=============================
+AI and Data Usage Information
+==============================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Querying with natural language in Compass is powered by generative AI, 
+and may give inaccurate responses. Please see our `Generative AI FAQ 
+<https://dochub.mongodb.org/core/faq-ai-features>`__ 
+for more information about AI in MongoDB products.
+
+Third Party Providers
+---------------------
+
+This feature currently uses the `Azure OpenAI Service
+<https://azure.microsoft.com/en-us/products/ai-services/openai-service>`__ 
+hosted by Microsoft. 
+
+How Your Data is Used
+---------------------
+
+When you query with natural language in Compass, the schema of the 
+collection you are querying including collection name, field names, 
+and types. 
+
+The information that is sent is not shared with any other third 
+parties or stored by the AI provider. We do not send database 
+connection strings, credentials, or raw data from your databases. 
+
+Disable Natural Language Querying
+---------------------------------
+
+Natural language querying in Compass is available if you have 
+enabled the Compass :guilabel:`Use Generative AI` setting and logged 
+into Atlas. If you no longer want to use the feature, you can ignore it 
+and no data will be sent to generative AI models. If you would like to 
+prevent usage of this feature entirely, you can turn it off in 
+Compass :ref:`global configuration file <config-file>`.

--- a/source/query-with-natural-language/ai-and-data-usage-information.txt
+++ b/source/query-with-natural-language/ai-and-data-usage-information.txt
@@ -10,7 +10,7 @@ AI and Data Usage Information
    :depth: 1
 
 Querying with natural language in Compass is powered by Generative AI
-(Gen AI), and may give inaccurate responses. Please see our `Generative AI FAQ 
+(Gen AI), and may give inaccurate responses. See our `Generative AI FAQ 
 <https://dochub.mongodb.org/core/faq-ai-features>`__ 
 for more information about Gen AI in MongoDB products.
 
@@ -29,7 +29,7 @@ collection you are querying including the collection name, field names,
 and types. 
 
 The information that is sent is not shared with any other third 
-parties or stored by the AI provider. We do not send database 
+parties or stored by the AI provider. We do not share database 
 connection strings, credentials, or raw data from your databases. 
 
 Disable Natural Language Querying

--- a/source/query-with-natural-language/ai-and-data-usage-information.txt
+++ b/source/query-with-natural-language/ai-and-data-usage-information.txt
@@ -24,10 +24,14 @@ hosted by Microsoft.  This is subject to change in the future.
 How Your Data is Used
 ---------------------
 
-When you query with natural language in Compass, the following information is sent to MongoDB’s backend and/or the third party AI provider:
-The schema of the collection you are querying (including collection name, field names, and types). 
+When you query with natural language in Compass, the following 
+information is sent to MongoDB’s backend and/or the third party 
+AI provider: The schema of the collection you are querying 
+(including collection name, field names, and types). 
 
-The information that is sent will not be shared with any other third parties or stored by the AI provider. We do not send database connection strings, credentials, or rows/documents from your databases. 
+The information that is sent will not be shared with any other third 
+parties or stored by the AI provider. We do not send database 
+connection strings, credentials, or rows/documents from your databases. 
 
 Disable Natural Language Querying
 ---------------------------------

--- a/source/query-with-natural-language/query-with-natural-language.txt
+++ b/source/query-with-natural-language/query-with-natural-language.txt
@@ -66,7 +66,7 @@ is subject to MongoDB's:
 .. toctree::
    :titlesonly:
    
-   /query-with-natural-language/ai-and-data-usage-information
    /query-with-natural-language/enable-natural-language-querying
    /query-with-natural-language/prompt-natural-language-query
    /query-with-natural-language/prompt-natural-language-aggregation
+   /query-with-natural-language/ai-and-data-usage-information

--- a/source/query-with-natural-language/query-with-natural-language.txt
+++ b/source/query-with-natural-language/query-with-natural-language.txt
@@ -65,7 +65,8 @@ is subject to MongoDB's:
 
 .. toctree::
    :titlesonly:
-
+   
+   /query-with-natural-language/ai-and-data-usage-information
    /query-with-natural-language/enable-natural-language-querying
    /query-with-natural-language/prompt-natural-language-query
    /query-with-natural-language/prompt-natural-language-aggregation


### PR DESCRIPTION
## DESCRIPTION

Adding a `AI and Data Usage Information` page to the Natural Language Querying Drawer.

LGTM'd over slack.

## STAGING

https://preview-mongodbianfmongodb.gatsbyjs.io/compass/DOCSP-37108/query-with-natural-language/ai-and-data-usage-information/

## JIRA

https://jira.mongodb.org/browse/DOCSP-37108

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65d7aae47111165982588c3a

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)