### PR TITLE
DOCSP-37238 Add note about transactions to bulk update

### DIFF
--- a/source/documents/modify-multiple.txt
+++ b/source/documents/modify-multiple.txt
@@ -28,6 +28,10 @@ About this Task
 - The :guilabel:`Update Documents` modal does not support any ``options`` 
   parameters such as upsert, writeConcern, or collation.
 
+- Previews of the documents affected by bulk update operations are 
+  only available if your database is configured to support transactions.
+  For details on enabling transactions see :ref:`transactions`. 
+
 Before you Begin
 ----------------
 

--- a/source/documents/modify-multiple.txt
+++ b/source/documents/modify-multiple.txt
@@ -29,7 +29,7 @@ About this Task
   parameters such as upsert, writeConcern, or collation.
 
 - Previews of the documents affected by bulk update operations are 
-  only available if your database is configured to support transactions.
+  only visible if your database is configured to support transactions.
   For details, see :ref:`transactions`. 
 
 Before you Begin

--- a/source/documents/modify-multiple.txt
+++ b/source/documents/modify-multiple.txt
@@ -30,7 +30,7 @@ About this Task
 
 - Previews of the documents affected by bulk update operations are 
   only available if your database is configured to support transactions.
-  For details on enabling transactions see :ref:`transactions`. 
+  For details, see :ref:`transactions`. 
 
 Before you Begin
 ----------------


### PR DESCRIPTION
## DESCRIPTION

Adding a recently discovered caveat to using the document preview modal in the Compass multiple modify workflow.

## STAGING

https://preview-mongodbianfmongodb.gatsbyjs.io/compass/DOCSP-37238/documents/modify-multiple/

## JIRA

https://jira.mongodb.org/browse/DOCSP-37238

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65e0d41d11db7b0427468d7d

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)