### PR TITLE
DOCSP-33037 doc that some out stages are now filtered out

### DIFF
--- a/source/query-plan.txt
+++ b/source/query-plan.txt
@@ -23,6 +23,13 @@ On the :guilabel:`Explain Plan` modal, you can view the explain stages as a
 tree. You can also view the explain details in raw JSON format by selecting 
 the :guilabel:`Raw Output` view.
 
+.. note:: 
+
+   The :guilabel:`Explain Plan` doesn't show aggregation pipeline stages
+   such as :pipeline:`$merge` and :pipeline:`$out` because
+   |compass-short| ignores all out stages from the aggregation before 
+   running the explain plan.
+
 The explain plan includes a :guilabel:`Query Performance Summary` with 
 information on the execution of your query such as: 
 


### PR DESCRIPTION
## DESCRIPTION
Documents that when requesting explain plan for aggregation pipelines, out stages like $merge and $out are now ignored / removed from the pipeline.

## STAGING
https://preview-mongodbkanchanamongodb.gatsbyjs.io/compass/DOCSP-33037/query-plan/

## JIRA
https://jira.mongodb.org/browse/DOCSP-33037

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6605abc86fc5f04850db683c

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)