### PR TITLE
Release notes for 1.42.5

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -30,7 +30,7 @@ toc_landing_pages = [
 
 [constants]
 download-page = "`downloads page <https://www.mongodb.com/try/download/compass>`__"
-current-version = "1.40.4"
+current-version = "1.42.5"
 atlas = "MongoDB Atlas"
 qe = "Queryable Encryption"
 qe-preview = "{+qe+} Public Preview"

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -10,10 +10,37 @@ Release Notes
    :depth: 1
    :class: twocols
 
+|compass| 1.42.5
+----------------
+
+*Released April 08, 2024*
+
+New Features
+
+- Updates atlas login screen flow (:issue:`COMPASS-7755`)
+- Handles collection subtab from link (:issue:`COMPASS-7731`)
+- Z-indexed stacked components (:issue:`COMPASS-7732`)
+- Removes collapsing/expanding the sidebar (:issue:`COMPASS-7812`)
+- Updates the “Use Generative AI” settings flow (:issue:`COMPASS-7756`)
+
+Bug Fixes
+
+- Show the in-progress index in the list again (:issue:`COMPASS-7789`)
+- Do not throw when rendering invalid dates (:issue:`COMPASS-7749`)
+- Can't sign out if not signed in yet (:issue:`COMPASS-7787`)
+- Click current op for details scoping error (:issue:`COMPASS-7805`)
+
+`Full changelog available on GitHub
+<https://github.com/mongodb-js/compass/compare/v1.42.3...v1.42.5>`__
+
+.. note::
+
+  |compass| version 1.42.4 was not released.
+
 |compass| 1.42.3
 ----------------
 
-*Released March, 20 2024*
+*Released March 20, 2024*
 
 New Features
 
@@ -37,7 +64,7 @@ Bug Fixes
 |compass| 1.42.2
 ----------------
 
-*Released March, 01 2024*
+*Released March 01, 2024*
 
 New Features
 

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -17,10 +17,10 @@ Release Notes
 
 New Features
 
-- Updates atlas login screen flow (:issue:`COMPASS-7755`)
+- Updates Atlas login screen flow (:issue:`COMPASS-7755`)
 - Handles collection subtab from link (:issue:`COMPASS-7731`)
 - Z-indexed stacked components (:issue:`COMPASS-7732`)
-- Removes collapsing/expanding the sidebar (:issue:`COMPASS-7812`)
+- Removes the ability to collapse the sidebar (:issue:`COMPASS-7812`)
 - Updates the “Use Generative AI” settings flow (:issue:`COMPASS-7756`)
 
 Bug Fixes


### PR DESCRIPTION
## DESCRIPTION
Adds release notes for 1.42.5 and a note that 1.42.4 was not released.

## STAGING
https://preview-mongodbmdbashley.gatsbyjs.io/compass/DOCSP-38377-1.42.5-release-notes/release-notes/

## JIRA
https://jira.mongodb.org/browse/DOCSP-38377

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=661826013a5920a291491b7d

## Self-Review Checklist

- [X] Is this free of any warnings or errors in the RST?
- [X] Is this free of spelling errors?
- [X] Is this free of grammatical errors?
- [X] Is this free of staging / rendering issues?
- [X] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)