### PR TITLE
DOCSP-38842: Fixes typo in two places

### DIFF
--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -69,7 +69,7 @@ Settings
      - Allow |compass-short| to use generative AI for natural language querying.
        This feature requires an Atlas login and a deployed Atlas cluster.
 
-   * - :ref:`enableDevtools <compass-enable-dev-tools>`
+   * - :ref:`enableDevTools <compass-enable-dev-tools>`
      - Enable Chrome DevTools in |compass-short|.
 
        To learn more, see :ref:`compass-enable-dev-tools`.

--- a/source/settings/read-only.txt
+++ b/source/settings/read-only.txt
@@ -25,7 +25,7 @@ By default, |compass-short| disables the ``readOnly`` option.
 If the ``readOnly`` option is enabled, you cannot enable the following options: 
 
 - :ref:`enableShell <embedded-mongodb-shell>`
-- :ref:`enableDevtools <compass-enable-dev-tools>`
+- :ref:`enableDevTools <compass-enable-dev-tools>`
 
 Procedure
 ---------


### PR DESCRIPTION
## DESCRIPTION
Typo: It's enableDevTools, not enableDevtools.


## STAGING
https://preview-mongodbsaraholsonmongodb.gatsbyjs.io/compass/DOCSP-38842/settings/config-file/#settings
https://preview-mongodbsaraholsonmongodb.gatsbyjs.io/compass/DOCSP-38842/settings/read-only/

## JIRA
https://jira.mongodb.org/browse/DOCSP-38842

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=662303b7b67dbf804a8e3b83

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)