### PR TITLE
DOCSP-40181 Compass GenAI Sample Documents

### DIFF
--- a/source/query-with-natural-language/ai-and-data-usage-information.txt
+++ b/source/query-with-natural-language/ai-and-data-usage-information.txt
@@ -32,10 +32,11 @@ AI provider:
 - The schema of the collection you are querying, 
   including database name, collection name, field names, and types. 
 - Sample field values. This is an optional setting to improve the 
-  quality of recommendations. You can manage this through 
-  ``Enable Sending Sample Field Values`` setting in 
+  quality of recommendations. You can manage this through the
+  ``Enable sending sample field values with query and aggregation 
+  generation requests`` setting in 
   :ref:`Compass settings <compass-settings-reference>`. This setting 
-  is off by default. 
+  is off by default.
 
 The information that is sent will not be shared with any other third 
 parties or stored by the AI provider. We do not send database 

--- a/source/query-with-natural-language/ai-and-data-usage-information.txt
+++ b/source/query-with-natural-language/ai-and-data-usage-information.txt
@@ -31,10 +31,9 @@ AI provider:
 - The full text of your natural language prompt.
 - The schema of the collection you are querying, 
   including database name, collection name, field names, and types. 
-- Sample field values. This is an optional setting to improve the 
-  quality of recommendations. You can manage this through the
-  ``Enable sending sample field values with query and aggregation 
-  generation requests`` setting in 
+- Enable sending sample field values. This is an optional setting to 
+  improve the quality of recommendations. You can manage this through the
+  ``Enable sending sample field values`` setting in 
   :ref:`Compass settings <compass-settings-reference>`. This setting 
   is off by default.
 

--- a/source/query-with-natural-language/ai-and-data-usage-information.txt
+++ b/source/query-with-natural-language/ai-and-data-usage-information.txt
@@ -31,6 +31,11 @@ AI provider:
 - The full text of your natural language prompt.
 - The schema of the collection you are querying, 
   including database name, collection name, field names, and types. 
+- Sample field values. This is an optional setting to improve the 
+  quality of recommendations. You can manage this through 
+  ``Enable Sending Sample Field Values`` setting in 
+  :ref:`Compass settings <compass-settings-reference>`. This setting 
+  is off by default. 
 
 The information that is sent will not be shared with any other third 
 parties or stored by the AI provider. We do not send database 

--- a/source/settings/settings-reference.txt
+++ b/source/settings/settings-reference.txt
@@ -158,6 +158,14 @@ You can configure the following settings on the |compass| interface:
      - Enables :ref:`natural language querying <query-natural-language>` and allows 
        the use of AI features in Compass which make requests to 3rd party services.
 
+   * - Enable Sending Sample Field Values with Query and Aggregation Generation Requests
+     - Artificial Intelligence
+     - Enables sharing of field values with the MongoDB AI provider 
+       from a set of sample documents. This setting can improve 
+       responses from natural language querying prompts.
+
+
+
 Learn More
 ----------
 

--- a/source/settings/settings-reference.txt
+++ b/source/settings/settings-reference.txt
@@ -158,7 +158,8 @@ You can configure the following settings on the |compass| interface:
      - Enables :ref:`natural language querying <query-natural-language>` and allows 
        the use of AI features in Compass which make requests to 3rd party services.
 
-   * - Enable sending sample field values with query and aggregation generation requests
+   * - Enable sending sample field values with query and aggregation 
+       generation requests
      - Artificial Intelligence
      - Enables sharing of sample field values with the MongoDB AI 
        provider. This setting can improve responses from 

--- a/source/settings/settings-reference.txt
+++ b/source/settings/settings-reference.txt
@@ -158,13 +158,12 @@ You can configure the following settings on the |compass| interface:
      - Enables :ref:`natural language querying <query-natural-language>` and allows 
        the use of AI features in Compass which make requests to 3rd party services.
 
-   * - Enable Sending Sample Field Values with Query and Aggregation Generation Requests
+   * - Enable sending sample field values with query and aggregation generation requests
      - Artificial Intelligence
-     - Enables sharing of field values with the MongoDB AI provider 
-       from a set of sample documents. This setting can improve 
-       responses from natural language querying prompts.
-
-
+     - Enables sharing of sample field values with the MongoDB AI 
+       provider. This setting can improve responses from 
+       :ref:`natural language querying <query-natural-language>` 
+       prompts.
 
 Learn More
 ----------

--- a/source/settings/settings-reference.txt
+++ b/source/settings/settings-reference.txt
@@ -158,8 +158,7 @@ You can configure the following settings on the |compass| interface:
      - Enables :ref:`natural language querying <query-natural-language>` and allows 
        the use of AI features in Compass which make requests to 3rd party services.
 
-   * - Enable sending sample field values with query and aggregation 
-       generation requests
+   * - Enable sending sample field values
      - Artificial Intelligence
      - Enables sharing of sample field values with the MongoDB AI 
        provider. This setting can improve responses from 


### PR DESCRIPTION
## DESCRIPTION

- Document the new `Artificial Intelligence` setting `Enable sending sample field values with query and aggregation generation requests` introduced in `1.43.1`. 
- Note after discussion with Rhys, the setting will be updated to `Enable sending sample field values`.

![Screenshot 2024-06-11 at 4 04 53 PM](https://github.com/mongodb/docs-compass/assets/85948430/cd5650e7-dcab-4ea4-9d6d-62fde8929284)


## STAGING

https://preview-mongodbianfmongodb.gatsbyjs.io/compass/DOCSP-40181/settings/settings-reference/#settings

https://preview-mongodbianfmongodb.gatsbyjs.io/compass/DOCSP-40181/query-with-natural-language/ai-and-data-usage-information/#how-your-data-is-used

## JIRA

https://jira.mongodb.org/browse/DOCSP-40181

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6668a479ebce19f3140003c1

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)