### PR TITLE
DOCSP-40542 Compass Quit Functionality Update

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -61,7 +61,7 @@ rst_epilog = '\n'.join([
     '.. |hardlink| replace:: http://docs.mongodb.com/compass/',
     '.. |compass| replace:: MongoDB Compass',
     '.. |compass-short| replace:: Compass',
-    '.. |tickmark| replace:: :kbd:`unicode:: U+0060`',
+    '.. |tickmark| replace:: :kbd:`X`',
     '.. |checkmark| replace:: :icon:`check-circle`',
     '.. |2fa| replace:: :abbr:`2FA (Two Factor Authentication)`',
     '.. |api| replace:: :abbr:`API (Application Programming Interface)`',

--- a/conf.py
+++ b/conf.py
@@ -61,7 +61,7 @@ rst_epilog = '\n'.join([
     '.. |hardlink| replace:: http://docs.mongodb.com/compass/',
     '.. |compass| replace:: MongoDB Compass',
     '.. |compass-short| replace:: Compass',
-    '.. |tickmark| replace:: :kbd:`X`',
+    '.. |tickmark| replace:: :icon:`check-circle`',
     '.. |checkmark| replace:: :icon:`check-circle`',
     '.. |2fa| replace:: :abbr:`2FA (Two Factor Authentication)`',
     '.. |api| replace:: :abbr:`API (Application Programming Interface)`',

--- a/conf.py
+++ b/conf.py
@@ -61,7 +61,6 @@ rst_epilog = '\n'.join([
     '.. |hardlink| replace:: http://docs.mongodb.com/compass/',
     '.. |compass| replace:: MongoDB Compass',
     '.. |compass-short| replace:: Compass',
-    '.. |tickmark| replace:: :icon:`check-circle`',
     '.. |checkmark| replace:: :icon:`check-circle`',
     '.. |2fa| replace:: :abbr:`2FA (Two Factor Authentication)`',
     '.. |api| replace:: :abbr:`API (Application Programming Interface)`',

--- a/conf.py
+++ b/conf.py
@@ -61,7 +61,7 @@ rst_epilog = '\n'.join([
     '.. |hardlink| replace:: http://docs.mongodb.com/compass/',
     '.. |compass| replace:: MongoDB Compass',
     '.. |compass-short| replace:: Compass',
-    '.. |tickmark| replace:: ```',
+    '.. |tickmark| replace:: unicode:: U+0060',
     '.. |checkmark| replace:: :icon:`check-circle`',
     '.. |2fa| replace:: :abbr:`2FA (Two Factor Authentication)`',
     '.. |api| replace:: :abbr:`API (Application Programming Interface)`',

--- a/conf.py
+++ b/conf.py
@@ -61,6 +61,7 @@ rst_epilog = '\n'.join([
     '.. |hardlink| replace:: http://docs.mongodb.com/compass/',
     '.. |compass| replace:: MongoDB Compass',
     '.. |compass-short| replace:: Compass',
+    '.. |tickmark| replace:: `',
     '.. |checkmark| replace:: :icon:`check-circle`',
     '.. |2fa| replace:: :abbr:`2FA (Two Factor Authentication)`',
     '.. |api| replace:: :abbr:`API (Application Programming Interface)`',

--- a/conf.py
+++ b/conf.py
@@ -61,7 +61,7 @@ rst_epilog = '\n'.join([
     '.. |hardlink| replace:: http://docs.mongodb.com/compass/',
     '.. |compass| replace:: MongoDB Compass',
     '.. |compass-short| replace:: Compass',
-    '.. |tickmark| replace:: `',
+    '.. |tickmark| replace:: ```',
     '.. |checkmark| replace:: :icon:`check-circle`',
     '.. |2fa| replace:: :abbr:`2FA (Two Factor Authentication)`',
     '.. |api| replace:: :abbr:`API (Application Programming Interface)`',

--- a/conf.py
+++ b/conf.py
@@ -61,7 +61,7 @@ rst_epilog = '\n'.join([
     '.. |hardlink| replace:: http://docs.mongodb.com/compass/',
     '.. |compass| replace:: MongoDB Compass',
     '.. |compass-short| replace:: Compass',
-    '.. |tickmark| replace:: unicode:: U+0060',
+    '.. |tickmark| replace:: :kbd:`unicode:: U+0060`',
     '.. |checkmark| replace:: :icon:`check-circle`',
     '.. |2fa| replace:: :abbr:`2FA (Two Factor Authentication)`',
     '.. |api| replace:: :abbr:`API (Application Programming Interface)`',

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -187,7 +187,7 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
    * - Web Shell
      - Toggle shell
      - :kbd:`Ctrl` + `````
-     - :kbd:`Ctrl` + :kbd:`U+0060`
+     - :kbd:`Ctrl` + :kbd:`|checkmark|`
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -187,7 +187,7 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
    * - Web Shell
      - Toggle shell
      - :kbd:`Ctrl` + `````
-     - :kbd:`Ctrl` + :kbd:```
+     - :kbd:`Ctrl` + :kbd:`|tickmark|`
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -27,11 +27,6 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
      - ``F1``
 
    * - Menu
-     - Quit application
-     - ``Ctrl`` + ``Q``
-     - ``Cmd`` + ``Q``
-
-   * - Menu
      - Show settings
      - ``Ctrl`` + ``,``
      - ``Cmd`` + ``,``
@@ -130,6 +125,11 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
      - Find
      - ``Ctrl`` + ``F``
      - ``Cmd`` + ``F``
+
+   * - General
+     - Quit application \ toggle quit confirmation dialog
+     - ``Ctrl`` + ``Q``
+     - ``Cmd`` + ``Q``
 
    * - Workspace
      - Navigate to next tab

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -187,7 +187,7 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
    * - Web Shell
      - Toggle shell
      - :kbd:`Ctrl` + `````
-     - :kbd:`Ctrl` + |tickmark|
+     - :kbd:`Ctrl` + :kbd:`U+0060`
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -2,7 +2,7 @@
 Keyboard Shortcuts
 ==================
 
-|x| replace:: ``x``
+.. |x| replace:: ``x``
 
 .. contents:: On this page
    :local:

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -187,7 +187,7 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
    * - Web Shell
      - Toggle shell
      - :kbd:`Ctrl` + `````
-     - :kbd:`Ctrl` + :kbd:`|tickmark|`
+     - :kbd:`Ctrl` + |tickmark|
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -187,7 +187,7 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
    * - Web Shell
      - Toggle shell
      - :kbd:`Ctrl` + `````
-     - :kbd:`Ctrl` + :kbd:`|`|`
+     - :kbd:`Ctrl` + :kbd:```
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -188,8 +188,8 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
 
    * - Web Shell
      - Toggle shell
-     - :kbd:`Ctrl` + :kbd:```
-     - :kbd:`Ctrl` + :kbd:```
+     - :kbd:`Ctrl` + :kbd:` ` `
+     - :kbd:`Ctrl` + :kbd:` ` `
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -23,210 +23,210 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
 
    * - Menu
      - Online help
-     -:kbd:`F1`
-     -:kbd:`F1`
+     - :kbd:`F1`
+     - :kbd:`F1`
 
    * - Menu
      - Quit application
-     -:kbd:`Ctrl` +:kbd:`Q`
-     -:kbd:`Cmd` +:kbd:`Q`
+     - :kbd:`Ctrl` +:kbd:`Q`
+     - :kbd:`Cmd` +:kbd:`Q`
 
    * - Menu
      - Show settings
-     -:kbd:`Ctrl` +:kbd:`,`
-     -:kbd:`Cmd` +:kbd:`,`
+     - :kbd:`Ctrl` +:kbd:`,`
+     - :kbd:`Cmd` +:kbd:`,`
 
    * - Menu
      - Hide window
-     -:kbd:`Ctrl` +:kbd:`H`
-     -:kbd:`Cmd` +:kbd:`H`
+     - :kbd:`Ctrl` +:kbd:`H`
+     - :kbd:`Cmd` +:kbd:`H`
 
    * - Menu
      - Hide other windows
-     -:kbd:`Ctrl` +:kbd:`Shift` +:kbd:`H`
-     -:kbd:`Cmd` +:kbd:`Shift` +:kbd:`H`
+     - :kbd:`Ctrl` +:kbd:`Shift` +:kbd:`H`
+     - :kbd:`Cmd` +:kbd:`Shift` +:kbd:`H`
 
    * - Menu
      - Open a new Compass window
-     -:kbd:`Ctrl` +:kbd:`N`
-     -:kbd:`Cmd` +:kbd:`N`
+     - :kbd:`Ctrl` +:kbd:`N`
+     - :kbd:`Cmd` +:kbd:`N`
 
    * - Menu
      - Share schema as JSON
-     -:kbd:`Alt` +:kbd:`Ctrl` +:kbd:`S`
-     -:kbd:`Alt` +:kbd:`Cmd` +:kbd:`S`
+     - :kbd:`Alt` +:kbd:`Ctrl` +:kbd:`S`
+     - :kbd:`Alt` +:kbd:`Cmd` +:kbd:`S`
 
    * - Menu
      - Reload screen
-     -:kbd:`Ctrl` +:kbd:`Shift` +:kbd:`R`
-     -:kbd:`Cmd` +:kbd:`Shift` +:kbd:`R`
+     - :kbd:`Ctrl` +:kbd:`Shift` +:kbd:`R`
+     - :kbd:`Cmd` +:kbd:`Shift` +:kbd:`R`
 
    * - Menu
      - Reload data
-     -:kbd:`Ctrl` +:kbd:`R`
-     -:kbd:`Cmd` +:kbd:`R`
+     - :kbd:`Ctrl` +:kbd:`R`
+     - :kbd:`Cmd` +:kbd:`R`
 
    * - Menu
      - Toggle sidebar
-     -:kbd:`Ctrl` +:kbd:`Shift` +:kbd:`D`
-     -:kbd:`Cmd` +:kbd:`Shift` +:kbd:`D`
+     - :kbd:`Ctrl` +:kbd:`Shift` +:kbd:`D`
+     - :kbd:`Cmd` +:kbd:`Shift` +:kbd:`D`
 
    * - Menu
      - Actual size
-     -:kbd:`Ctrl` +:kbd:`0`
-     -:kbd:`Cmd` +:kbd:`0`
+     - :kbd:`Ctrl` +:kbd:`0`
+     - :kbd:`Cmd` +:kbd:`0`
 
    * - Menu
      - Zoom in
-     -:kbd:`Ctrl` +:kbd:`=`
-     -:kbd:`Cmd` +:kbd:`=`
+     - :kbd:`Ctrl` +:kbd:`=`
+     - :kbd:`Cmd` +:kbd:`=`
 
    * - Menu
      - Zoom out
-     -:kbd:`Ctrl` +:kbd:`-`
-     -:kbd:`Cmd` +:kbd:`-`
+     - :kbd:`Ctrl` +:kbd:`-`
+     - :kbd:`Cmd` +:kbd:`-`
 
    * - Menu
      - Toggle DevTools
-     -:kbd:`Alt` +:kbd:`Ctrl` +:kbd:`I`
-     -:kbd:`Alt` +:kbd:`Cmd` +:kbd:`I`
+     - :kbd:`Alt` +:kbd:`Ctrl` +:kbd:`I`
+     - :kbd:`Alt` +:kbd:`Cmd` +:kbd:`I`
 
    * - Menu
      - Minimize
-     -:kbd:`Ctrl` +:kbd:`M`
-     -:kbd:`Cmd` +:kbd:`M`
+     - :kbd:`Ctrl` +:kbd:`M`
+     - :kbd:`Cmd` +:kbd:`M`
 
    * - General
      - Undo
-     -:kbd:`Ctrl` +:kbd:`Z`
-     -:kbd:`Cmd` +:kbd:`Z`
+     - :kbd:`Ctrl` +:kbd:`Z`
+     - :kbd:`Cmd` +:kbd:`Z`
 
    * - General
      - Redo
-     -:kbd:`Ctrl` +:kbd:`Shift` +:kbd:`Z`
-     -:kbd:`Cmd` +:kbd:`Shift` +:kbd:`Z`
+     - :kbd:`Ctrl` +:kbd:`Shift` +:kbd:`Z`
+     - :kbd:`Cmd` +:kbd:`Shift` +:kbd:`Z`
 
    * - General
      - Cut
-     -:kbd:`Ctrl` +:kbd:`X`
-     -:kbd:`Cmd` +:kbd:`X`
+     - :kbd:`Ctrl` +:kbd:`X`
+     - :kbd:`Cmd` +:kbd:`X`
 
    * - General
      - Copy
-     -:kbd:`Ctrl` +:kbd:`C`
-     -:kbd:`Cmd` +:kbd:`C`
+     - :kbd:`Ctrl` +:kbd:`C`
+     - :kbd:`Cmd` +:kbd:`C`
 
    * - General
      - Paste
-     -:kbd:`Ctrl + V`
-     -:kbd:`Cmd + V`
+     - :kbd:`Ctrl + V`
+     - :kbd:`Cmd + V`
 
    * - General
      - Select all
-     -:kbd:`Ctrl` +:kbd:`A`
-     -:kbd:`Cmd` +:kbd:`A`
+     - :kbd:`Ctrl` +:kbd:`A`
+     - :kbd:`Cmd` +:kbd:`A`
 
    * - General
      - Find
-     -:kbd:`Ctrl` +:kbd:`F`
-     -:kbd:`Cmd` +:kbd:`F`
+     - :kbd:`Ctrl` +:kbd:`F`
+     - :kbd:`Cmd` +:kbd:`F`
 
    * - Workspace
      - Navigate to next tab
-     -:kbd:`Ctrl` +:kbd:`Shift` +:kbd:`]`
-     -:kbd:`Cmd` +:kbd:`Shift` +:kbd:`]`
+     - :kbd:`Ctrl` +:kbd:`Shift` +:kbd:`]`
+     - :kbd:`Cmd` +:kbd:`Shift` +:kbd:`]`
 
    * - Workspace
      - Navigate to previous tab
-     -:kbd:`Ctrl` +:kbd:`Shift` +:kbd:`[`
-     -:kbd:`Cmd` +:kbd:`Shift` +:kbd:`[`
+     - :kbd:`Ctrl` +:kbd:`Shift` +:kbd:`[`
+     - :kbd:`Cmd` +:kbd:`Shift` +:kbd:`[`
 
    * - Workspace
      - Close current tab
-     -:kbd:`Ctrl` + :kbd:`Shift` +:kbd:`W`
-     -:kbd:`Cmd` + :kbd:`Shift` +:kbd:`W`
+     - :kbd:`Ctrl` + :kbd:`Shift` +:kbd:`W`
+     - :kbd:`Cmd` + :kbd:`Shift` +:kbd:`W`
 
    * - Workspace
      - Open new tab
-     -:kbd:`Ctrl` +:kbd:`T`
-     -:kbd:`Cmd` +:kbd:`T`
+     - :kbd:`Ctrl` +:kbd:`T`
+     - :kbd:`Cmd` +:kbd:`T`
 
    * - Aggregation Focus Mode
      - Add a new stage after current one
-     -:kbd:`Ctrl` +:kbd:`Shift` +:kbd:`B`
-     -:kbd:`Cmd` +:kbd:`Shift` +:kbd:`B`
+     - :kbd:`Ctrl` +:kbd:`Shift` +:kbd:`B`
+     - :kbd:`Cmd` +:kbd:`Shift` +:kbd:`B`
 
    * - Aggregation Focus Mode
      - Add a new stage before current one
-     -:kbd:`Ctrl` +:kbd:`Shift` +:kbd:`A`
-     -:kbd:`Cmd` +:kbd:`Shift` +:kbd:`A`
+     - :kbd:`Ctrl` +:kbd:`Shift` +:kbd:`A`
+     - :kbd:`Cmd` +:kbd:`Shift` +:kbd:`A`
 
    * - Aggregation Focus Mode
      - Navigate to next stage
-     -:kbd:`Ctrl` +:kbd:`Shift` +:kbd:`9`
-     -:kbd:`Cmd` +:kbd:`Shift` +:kbd:`9`
+     - :kbd:`Ctrl` +:kbd:`Shift` +:kbd:`9`
+     - :kbd:`Cmd` +:kbd:`Shift` +:kbd:`9`
 
    * - Aggregation Focus Mode
      - Navigate to previous stage
-     -:kbd:`Ctrl` +:kbd:`Shift` +:kbd:`0`
-     -:kbd:`Cmd` +:kbd:`Shift` +:kbd:`0`
+     - :kbd:`Ctrl` +:kbd:`Shift` +:kbd:`0`
+     - :kbd:`Cmd` +:kbd:`Shift` +:kbd:`0`
 
    * - Pipeline text editor
      - Comment out code
-     -:kbd:`Ctrl` +:kbd:`/`
-     -:kbd:`Cmd` +:kbd:`/`
+     - :kbd:`Ctrl` +:kbd:`/`
+     - :kbd:`Cmd` +:kbd:`/`
 
    * - All text editors
      - Prettify code
-     -:kbd:`Ctrl` +:kbd:`Shift` +:kbd:`B`
-     -:kbd:`Ctrl` +:kbd:`Shift` +:kbd:`B`
+     - :kbd:`Ctrl` +:kbd:`Shift` +:kbd:`B`
+     - :kbd:`Ctrl` +:kbd:`Shift` +:kbd:`B`
 
    * - Query bar
      - Submit query
-     -:kbd:`Enter (from the query bar)`
-     -:kbd:`Enter (from the query bar)`
+     - :kbd:`Enter (from the query bar)`
+     - :kbd:`Enter (from the query bar)`
 
    * - Web Shell
      - Toggle shell
-     -:kbd:`Ctrl` +:kbd:``
-     -:kbd:`Ctrl` +:kbd:``
+     - :kbd:`Ctrl` +:kbd:``
+     - :kbd:`Ctrl` +:kbd:``
 
    * - Web Shell
      - Deletes the next character
-     -:kbd:`Ctrl` +:kbd:`D`
-     -:kbd:`Ctrl` +:kbd:`D`
+     - :kbd:`Ctrl` +:kbd:`D`
+     - :kbd:`Ctrl` +:kbd:`D`
 
    * - Web Shell
      - Moves the cursor to the end of the line
-     -:kbd:`Ctrl` +:kbd:`E`
-     -:kbd:`Ctrl` +:kbd:`E`
+     - :kbd:`Ctrl` +:kbd:`E`
+     - :kbd:`Ctrl` +:kbd:`E`
 
    * - Web Shell
      - Moves the cursor forward one character
-     -:kbd:`Ctrl` +:kbd:`F`
-     -:kbd:`Ctrl` +:kbd:`F`
+     - :kbd:`Ctrl` +:kbd:`F`
+     - :kbd:`Ctrl` +:kbd:`F`
 
    * - Web Shell
      - Erases one character, similar to hitting backspace
-     -:kbd:`Ctrl` +:kbd:`H`
-     -:kbd:`Cmd` +:kbd:`H`
+     - :kbd:`Ctrl` +:kbd:`H`
+     - :kbd:`Cmd` +:kbd:`H`
 
    * - Web Shell
      - Clears the screen, similar to the clear command
-     -:kbd:`Ctrl` +:kbd:`L`
-     -:kbd:`Cmd` +:kbd:`L`
+     - :kbd:`Ctrl` +:kbd:`L`
+     - :kbd:`Cmd` +:kbd:`L`
 
    * - Web Shell
      - Swap the last two characters before the cursor
-     -:kbd:`Ctrl` +:kbd:`T`
-     -:kbd:`Ctrl` +:kbd:`T`
+     - :kbd:`Ctrl` +:kbd:`T`
+     - :kbd:`Ctrl` +:kbd:`T`
 
    * - Web Shell
      - Cycle backwards through command history
-     -:kbd:`↑`
-     -:kbd:`↑`
+     - :kbd:`↑`
+     - :kbd:`↑`
 
    * - Web Shell
      - Cycle forwards through command history
-     -:kbd:`↓`
-     -:kbd:`↓`
+     - :kbd:`↓`
+     - :kbd:`↓`

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -188,8 +188,8 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
 
    * - Web Shell
      - Toggle shell
-     - :kbd:`Ctrl` + :kbd:```
-     - :kbd:`Ctrl` + :kbd:```
+     - :kbd:`Ctrl` + :kbd:````
+     - :kbd:`Ctrl` + :kbd:````
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -26,6 +26,11 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
      - ``F1``
      - ``F1``
 
+   * - General
+     - Quit application
+     - ``Ctrl`` + ``Q``
+     - ``Cmd`` + ``Q``
+
    * - Menu
      - Show settings
      - ``Ctrl`` + ``,``
@@ -125,11 +130,6 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
      - Find
      - ``Ctrl`` + ``F``
      - ``Cmd`` + ``F``
-
-   * - General
-     - Quit application \ toggle quit confirmation dialog
-     - ``Ctrl`` + ``Q``
-     - ``Cmd`` + ``Q``
 
    * - Workspace
      - Navigate to next tab

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -189,7 +189,7 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
    * - Web Shell
      - Toggle shell
      - :kbd:`Ctrl` + `````
-     - :kbd:`Ctrl` + |x|
+     - :kbd:`Ctrl` +  :kbd:`̀`
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -189,7 +189,7 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
    * - Web Shell
      - Toggle shell
      - :kbd:`Ctrl` + `````
-     - :kbd:`Ctrl` +  :kbd:``̀ `
+     - :kbd:`Ctrl` +  :kbd:``̀`
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -189,7 +189,7 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
    * - Web Shell
      - Toggle shell
      - :kbd:`Ctrl` + `````
-     - :kbd:`Ctrl` +  :kbd:` `̀  `
+     - :kbd:`Ctrl` +  :kbd:``̀ `
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -189,7 +189,7 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
    * - Web Shell
      - Toggle shell
      - :kbd:`Ctrl` + `````
-     - :kbd:`Ctrl` +  :kbd:``̀`
+     - :kbd:`Ctrl` +  :kbd:`̀`
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -188,8 +188,8 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
 
    * - Web Shell
      - Toggle shell
-     - :kbd:`Ctrl` + :kbd:` ``` `
-     - :kbd:`Ctrl` + :kbd:` ``` `
+     - :kbd:`Ctrl` + :kbd:` `` `
+     - :kbd:`Ctrl` + :kbd:` `` `
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -118,8 +118,8 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
 
    * - General
      - Paste
-     - :kbd:`Ctrl + V`
-     - :kbd:`Cmd + V`
+     - :kbd:`Ctrl` + :kbd:`V`
+     - :kbd:`Cmd` + :kbd:`V`
 
    * - General
      - Select all

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -1,8 +1,8 @@
+.. _compass-keyboard-shortcuts:
+
 ==================
 Keyboard Shortcuts
 ==================
-
-.. |x| replace:: kbd:``
 
 .. contents:: On this page
    :local:

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -2,7 +2,7 @@
 Keyboard Shortcuts
 ==================
 
-.. default-domain:: mongodb
+.. |placeholder| replace:: `
 
 .. contents:: On this page
    :local:
@@ -188,8 +188,8 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
 
    * - Web Shell
      - Toggle shell
-     - :kbd:`Ctrl` + :kbd:``
-     - :kbd:`Ctrl` + :kbd:``
+     - :kbd:`Ctrl` + :kbd:`|placeholder|` + `````
+     - :kbd:`Ctrl` + :kbd:`|placeholder|` + `````
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -2,7 +2,7 @@
 Keyboard Shortcuts
 ==================
 
-.. |placeholder| replace:: `
+.. |placeholder| replace:: ``
 
 .. contents:: On this page
    :local:

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -2,7 +2,7 @@
 Keyboard Shortcuts
 ==================
 
-|x| replace:: sorting returned documents
+|x| replace:: :kbd:`x`
 
 .. contents:: On this page
    :local:
@@ -189,7 +189,7 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
    * - Web Shell
      - Toggle shell
      - :kbd:`Ctrl` + `````
-     - :kbd:`Ctrl` + :kbd:`|x|`
+     - :kbd:`Ctrl` + |x|
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -183,13 +183,13 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
 
    * - Query bar
      - Submit query
-     - :kbd:`Enter (from the query bar)`
-     - :kbd:`Enter (from the query bar)`
+     - :kbd:`Enter` (from the query bar)
+     - :kbd:`Enter` (from the query bar)
 
    * - Web Shell
      - Toggle shell
-     - :kbd:`Ctrl` + :kbd:``
-     - :kbd:`Ctrl` + :kbd:``
+     - :kbd:`Ctrl` + :kbd:```
+     - :kbd:`Ctrl` + :kbd:```
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -189,7 +189,7 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
    * - Web Shell
      - Toggle shell
      - :kbd:`Ctrl` + `````
-     - :kbd:`Ctrl` + |x|
+     - :kbd:`Ctrl` + :kbd:`|x|`
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -26,7 +26,7 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
      - ``F1``
      - ``F1``
 
-   * - General
+   * - Menu
      - Quit application
      - ``Ctrl`` + ``Q``
      - ``Cmd`` + ``Q``

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -2,6 +2,8 @@
 Keyboard Shortcuts
 ==================
 
+|x| replace:: sorting returned documents
+
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -187,7 +189,7 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
    * - Web Shell
      - Toggle shell
      - :kbd:`Ctrl` + `````
-     - :kbd:`Ctrl` + :kbd:`|checkmark|`
+     - :kbd:`Ctrl` + :kbd:`|x|`
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -2,7 +2,7 @@
 Keyboard Shortcuts
 ==================
 
-|x| replace:: :kbd:`x`
+|x| replace:: ``x``
 
 .. contents:: On this page
    :local:

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -188,8 +188,8 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
 
    * - Web Shell
      - Toggle shell
-     - :kbd:`Ctrl` + :kbd:````
-     - :kbd:`Ctrl` + :kbd:````
+     - :kbd:`Ctrl` + :kbd:```
+     - :kbd:`Ctrl` + :kbd:```
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -189,7 +189,7 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
    * - Web Shell
      - Toggle shell
      - :kbd:`Ctrl` + :kbd:`ˋ`
-     - :kbd:`Ctrl` +  :kbd:`̀`
+     - :kbd:`Ctrl` + :kbd:`ˋ`
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -187,7 +187,7 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
    * - Web Shell
      - Toggle shell
      - :kbd:`Ctrl` + `````
-     - :kbd:`Ctrl` + :kbd:`|tickmark|`
+     - :kbd:`Ctrl` + :kbd:`|`|`
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -23,210 +23,210 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
 
    * - Menu
      - Online help
-     -:kdb:`F1`
-     -:kdb:`F1`
+     -:kbd:`F1`
+     -:kbd:`F1`
 
    * - Menu
      - Quit application
-     -:kdb:`Ctrl` +:kdb:`Q`
-     -:kdb:`Cmd` +:kdb:`Q`
+     -:kbd:`Ctrl` +:kbd:`Q`
+     -:kbd:`Cmd` +:kbd:`Q`
 
    * - Menu
      - Show settings
-     -:kdb:`Ctrl` +:kdb:`,`
-     -:kdb:`Cmd` +:kdb:`,`
+     -:kbd:`Ctrl` +:kbd:`,`
+     -:kbd:`Cmd` +:kbd:`,`
 
    * - Menu
      - Hide window
-     -:kdb:`Ctrl` +:kdb:`H`
-     -:kdb:`Cmd` +:kdb:`H`
+     -:kbd:`Ctrl` +:kbd:`H`
+     -:kbd:`Cmd` +:kbd:`H`
 
    * - Menu
      - Hide other windows
-     -:kdb:`Ctrl` +:kdb:`Shift` +:kdb:`H`
-     -:kdb:`Cmd` +:kdb:`Shift` +:kdb:`H`
+     -:kbd:`Ctrl` +:kbd:`Shift` +:kbd:`H`
+     -:kbd:`Cmd` +:kbd:`Shift` +:kbd:`H`
 
    * - Menu
      - Open a new Compass window
-     -:kdb:`Ctrl` +:kdb:`N`
-     -:kdb:`Cmd` +:kdb:`N`
+     -:kbd:`Ctrl` +:kbd:`N`
+     -:kbd:`Cmd` +:kbd:`N`
 
    * - Menu
      - Share schema as JSON
-     -:kdb:`Alt` +:kdb:`Ctrl` +:kdb:`S`
-     -:kdb:`Alt` +:kdb:`Cmd` +:kdb:`S`
+     -:kbd:`Alt` +:kbd:`Ctrl` +:kbd:`S`
+     -:kbd:`Alt` +:kbd:`Cmd` +:kbd:`S`
 
    * - Menu
      - Reload screen
-     -:kdb:`Ctrl` +:kdb:`Shift` +:kdb:`R`
-     -:kdb:`Cmd` +:kdb:`Shift` +:kdb:`R`
+     -:kbd:`Ctrl` +:kbd:`Shift` +:kbd:`R`
+     -:kbd:`Cmd` +:kbd:`Shift` +:kbd:`R`
 
    * - Menu
      - Reload data
-     -:kdb:`Ctrl` +:kdb:`R`
-     -:kdb:`Cmd` +:kdb:`R`
+     -:kbd:`Ctrl` +:kbd:`R`
+     -:kbd:`Cmd` +:kbd:`R`
 
    * - Menu
      - Toggle sidebar
-     -:kdb:`Ctrl` +:kdb:`Shift` +:kdb:`D`
-     -:kdb:`Cmd` +:kdb:`Shift` +:kdb:`D`
+     -:kbd:`Ctrl` +:kbd:`Shift` +:kbd:`D`
+     -:kbd:`Cmd` +:kbd:`Shift` +:kbd:`D`
 
    * - Menu
      - Actual size
-     -:kdb:`Ctrl` +:kdb:`0`
-     -:kdb:`Cmd` +:kdb:`0`
+     -:kbd:`Ctrl` +:kbd:`0`
+     -:kbd:`Cmd` +:kbd:`0`
 
    * - Menu
      - Zoom in
-     -:kdb:`Ctrl` +:kdb:`=`
-     -:kdb:`Cmd` +:kdb:`=`
+     -:kbd:`Ctrl` +:kbd:`=`
+     -:kbd:`Cmd` +:kbd:`=`
 
    * - Menu
      - Zoom out
-     -:kdb:`Ctrl` +:kdb:`-`
-     -:kdb:`Cmd` +:kdb:`-`
+     -:kbd:`Ctrl` +:kbd:`-`
+     -:kbd:`Cmd` +:kbd:`-`
 
    * - Menu
      - Toggle DevTools
-     -:kdb:`Alt` +:kdb:`Ctrl` +:kdb:`I`
-     -:kdb:`Alt` +:kdb:`Cmd` +:kdb:`I`
+     -:kbd:`Alt` +:kbd:`Ctrl` +:kbd:`I`
+     -:kbd:`Alt` +:kbd:`Cmd` +:kbd:`I`
 
    * - Menu
      - Minimize
-     -:kdb:`Ctrl` +:kdb:`M`
-     -:kdb:`Cmd` +:kdb:`M`
+     -:kbd:`Ctrl` +:kbd:`M`
+     -:kbd:`Cmd` +:kbd:`M`
 
    * - General
      - Undo
-     -:kdb:`Ctrl` +:kdb:`Z`
-     -:kdb:`Cmd` +:kdb:`Z`
+     -:kbd:`Ctrl` +:kbd:`Z`
+     -:kbd:`Cmd` +:kbd:`Z`
 
    * - General
      - Redo
-     -:kdb:`Ctrl` +:kdb:`Shift` +:kdb:`Z`
-     -:kdb:`Cmd` +:kdb:`Shift` +:kdb:`Z`
+     -:kbd:`Ctrl` +:kbd:`Shift` +:kbd:`Z`
+     -:kbd:`Cmd` +:kbd:`Shift` +:kbd:`Z`
 
    * - General
      - Cut
-     -:kdb:`Ctrl` +:kdb:`X`
-     -:kdb:`Cmd` +:kdb:`X`
+     -:kbd:`Ctrl` +:kbd:`X`
+     -:kbd:`Cmd` +:kbd:`X`
 
    * - General
      - Copy
-     -:kdb:`Ctrl` +:kdb:`C`
-     -:kdb:`Cmd` +:kdb:`C`
+     -:kbd:`Ctrl` +:kbd:`C`
+     -:kbd:`Cmd` +:kbd:`C`
 
    * - General
      - Paste
-     -:kdb:`Ctrl + V`
-     -:kdb:`Cmd + V`
+     -:kbd:`Ctrl + V`
+     -:kbd:`Cmd + V`
 
    * - General
      - Select all
-     -:kdb:`Ctrl` +:kdb:`A`
-     -:kdb:`Cmd` +:kdb:`A`
+     -:kbd:`Ctrl` +:kbd:`A`
+     -:kbd:`Cmd` +:kbd:`A`
 
    * - General
      - Find
-     -:kdb:`Ctrl` +:kdb:`F`
-     -:kdb:`Cmd` +:kdb:`F`
+     -:kbd:`Ctrl` +:kbd:`F`
+     -:kbd:`Cmd` +:kbd:`F`
 
    * - Workspace
      - Navigate to next tab
-     -:kdb:`Ctrl` +:kdb:`Shift` +:kdb:`]`
-     -:kdb:`Cmd` +:kdb:`Shift` +:kdb:`]`
+     -:kbd:`Ctrl` +:kbd:`Shift` +:kbd:`]`
+     -:kbd:`Cmd` +:kbd:`Shift` +:kbd:`]`
 
    * - Workspace
      - Navigate to previous tab
-     -:kdb:`Ctrl` +:kdb:`Shift` +:kdb:`[`
-     -:kdb:`Cmd` +:kdb:`Shift` +:kdb:`[`
+     -:kbd:`Ctrl` +:kbd:`Shift` +:kbd:`[`
+     -:kbd:`Cmd` +:kbd:`Shift` +:kbd:`[`
 
    * - Workspace
      - Close current tab
-     -:kdb:`Ctrl` + :kdb:`Shift` +:kdb:`W`
-     -:kdb:`Cmd` + :kdb:`Shift` +:kdb:`W`
+     -:kbd:`Ctrl` + :kbd:`Shift` +:kbd:`W`
+     -:kbd:`Cmd` + :kbd:`Shift` +:kbd:`W`
 
    * - Workspace
      - Open new tab
-     -:kdb:`Ctrl` +:kdb:`T`
-     -:kdb:`Cmd` +:kdb:`T`
+     -:kbd:`Ctrl` +:kbd:`T`
+     -:kbd:`Cmd` +:kbd:`T`
 
    * - Aggregation Focus Mode
      - Add a new stage after current one
-     -:kdb:`Ctrl` +:kdb:`Shift` +:kdb:`B`
-     -:kdb:`Cmd` +:kdb:`Shift` +:kdb:`B`
+     -:kbd:`Ctrl` +:kbd:`Shift` +:kbd:`B`
+     -:kbd:`Cmd` +:kbd:`Shift` +:kbd:`B`
 
    * - Aggregation Focus Mode
      - Add a new stage before current one
-     -:kdb:`Ctrl` +:kdb:`Shift` +:kdb:`A`
-     -:kdb:`Cmd` +:kdb:`Shift` +:kdb:`A`
+     -:kbd:`Ctrl` +:kbd:`Shift` +:kbd:`A`
+     -:kbd:`Cmd` +:kbd:`Shift` +:kbd:`A`
 
    * - Aggregation Focus Mode
      - Navigate to next stage
-     -:kdb:`Ctrl` +:kdb:`Shift` +:kdb:`9`
-     -:kdb:`Cmd` +:kdb:`Shift` +:kdb:`9`
+     -:kbd:`Ctrl` +:kbd:`Shift` +:kbd:`9`
+     -:kbd:`Cmd` +:kbd:`Shift` +:kbd:`9`
 
    * - Aggregation Focus Mode
      - Navigate to previous stage
-     -:kdb:`Ctrl` +:kdb:`Shift` +:kdb:`0`
-     -:kdb:`Cmd` +:kdb:`Shift` +:kdb:`0`
+     -:kbd:`Ctrl` +:kbd:`Shift` +:kbd:`0`
+     -:kbd:`Cmd` +:kbd:`Shift` +:kbd:`0`
 
    * - Pipeline text editor
      - Comment out code
-     -:kdb:`Ctrl` +:kdb:`/`
-     -:kdb:`Cmd` +:kdb:`/`
+     -:kbd:`Ctrl` +:kbd:`/`
+     -:kbd:`Cmd` +:kbd:`/`
 
    * - All text editors
      - Prettify code
-     -:kdb:`Ctrl` +:kdb:`Shift` +:kdb:`B`
-     -:kdb:`Ctrl` +:kdb:`Shift` +:kdb:`B`
+     -:kbd:`Ctrl` +:kbd:`Shift` +:kbd:`B`
+     -:kbd:`Ctrl` +:kbd:`Shift` +:kbd:`B`
 
    * - Query bar
      - Submit query
-     -:kdb:`Enter (from the query bar)`
-     -:kdb:`Enter (from the query bar)`
+     -:kbd:`Enter (from the query bar)`
+     -:kbd:`Enter (from the query bar)`
 
    * - Web Shell
      - Toggle shell
-     -:kdb:`Ctrl` +:kdb:``
-     -:kdb:`Ctrl` +:kdb:``
+     -:kbd:`Ctrl` +:kbd:``
+     -:kbd:`Ctrl` +:kbd:``
 
    * - Web Shell
      - Deletes the next character
-     -:kdb:`Ctrl` +:kdb:`D`
-     -:kdb:`Ctrl` +:kdb:`D`
+     -:kbd:`Ctrl` +:kbd:`D`
+     -:kbd:`Ctrl` +:kbd:`D`
 
    * - Web Shell
      - Moves the cursor to the end of the line
-     -:kdb:`Ctrl` +:kdb:`E`
-     -:kdb:`Ctrl` +:kdb:`E`
+     -:kbd:`Ctrl` +:kbd:`E`
+     -:kbd:`Ctrl` +:kbd:`E`
 
    * - Web Shell
      - Moves the cursor forward one character
-     -:kdb:`Ctrl` +:kdb:`F`
-     -:kdb:`Ctrl` +:kdb:`F`
+     -:kbd:`Ctrl` +:kbd:`F`
+     -:kbd:`Ctrl` +:kbd:`F`
 
    * - Web Shell
      - Erases one character, similar to hitting backspace
-     -:kdb:`Ctrl` +:kdb:`H`
-     -:kdb:`Cmd` +:kdb:`H`
+     -:kbd:`Ctrl` +:kbd:`H`
+     -:kbd:`Cmd` +:kbd:`H`
 
    * - Web Shell
      - Clears the screen, similar to the clear command
-     -:kdb:`Ctrl` +:kdb:`L`
-     -:kdb:`Cmd` +:kdb:`L`
+     -:kbd:`Ctrl` +:kbd:`L`
+     -:kbd:`Cmd` +:kbd:`L`
 
    * - Web Shell
      - Swap the last two characters before the cursor
-     -:kdb:`Ctrl` +:kdb:`T`
-     -:kdb:`Ctrl` +:kdb:`T`
+     -:kbd:`Ctrl` +:kbd:`T`
+     -:kbd:`Ctrl` +:kbd:`T`
 
    * - Web Shell
      - Cycle backwards through command history
-     -:kdb:`↑`
-     -:kdb:`↑`
+     -:kbd:`↑`
+     -:kbd:`↑`
 
    * - Web Shell
      - Cycle forwards through command history
-     -:kdb:`↓`
-     -:kdb:`↓`
+     -:kbd:`↓`
+     -:kbd:`↓`

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -188,8 +188,8 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
 
    * - Web Shell
      - Toggle shell
-     - :kbd:`Ctrl` + :kbd:` `` `
-     - :kbd:`Ctrl` + :kbd:` `` `
+     - :kbd:`Ctrl` + :kbd:``
+     - :kbd:`Ctrl` + :kbd:``
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -28,93 +28,93 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
 
    * - Menu
      - Quit application
-     - :kbd:`Ctrl` +:kbd:`Q`
-     - :kbd:`Cmd` +:kbd:`Q`
+     - :kbd:`Ctrl` + :kbd:`Q`
+     - :kbd:`Cmd` + :kbd:`Q`
 
    * - Menu
      - Show settings
-     - :kbd:`Ctrl` +:kbd:`,`
-     - :kbd:`Cmd` +:kbd:`,`
+     - :kbd:`Ctrl` + :kbd:`,`
+     - :kbd:`Cmd` + :kbd:`,`
 
    * - Menu
      - Hide window
-     - :kbd:`Ctrl` +:kbd:`H`
-     - :kbd:`Cmd` +:kbd:`H`
+     - :kbd:`Ctrl` + :kbd:`H`
+     - :kbd:`Cmd` + :kbd:`H`
 
    * - Menu
      - Hide other windows
-     - :kbd:`Ctrl` +:kbd:`Shift` +:kbd:`H`
-     - :kbd:`Cmd` +:kbd:`Shift` +:kbd:`H`
+     - :kbd:`Ctrl` + :kbd:`Shift` + :kbd:`H`
+     - :kbd:`Cmd` + :kbd:`Shift` + :kbd:`H`
 
    * - Menu
      - Open a new Compass window
-     - :kbd:`Ctrl` +:kbd:`N`
-     - :kbd:`Cmd` +:kbd:`N`
+     - :kbd:`Ctrl` + :kbd:`N`
+     - :kbd:`Cmd` + :kbd:`N`
 
    * - Menu
      - Share schema as JSON
-     - :kbd:`Alt` +:kbd:`Ctrl` +:kbd:`S`
-     - :kbd:`Alt` +:kbd:`Cmd` +:kbd:`S`
+     - :kbd:`Alt` + :kbd:`Ctrl` + :kbd:`S`
+     - :kbd:`Alt` + :kbd:`Cmd` + :kbd:`S`
 
    * - Menu
      - Reload screen
-     - :kbd:`Ctrl` +:kbd:`Shift` +:kbd:`R`
-     - :kbd:`Cmd` +:kbd:`Shift` +:kbd:`R`
+     - :kbd:`Ctrl` + :kbd:`Shift` + :kbd:`R`
+     - :kbd:`Cmd` + :kbd:`Shift` + :kbd:`R`
 
    * - Menu
      - Reload data
-     - :kbd:`Ctrl` +:kbd:`R`
-     - :kbd:`Cmd` +:kbd:`R`
+     - :kbd:`Ctrl` + :kbd:`R`
+     - :kbd:`Cmd` + :kbd:`R`
 
    * - Menu
      - Toggle sidebar
-     - :kbd:`Ctrl` +:kbd:`Shift` +:kbd:`D`
-     - :kbd:`Cmd` +:kbd:`Shift` +:kbd:`D`
+     - :kbd:`Ctrl` + :kbd:`Shift` + :kbd:`D`
+     - :kbd:`Cmd` + :kbd:`Shift` + :kbd:`D`
 
    * - Menu
      - Actual size
-     - :kbd:`Ctrl` +:kbd:`0`
-     - :kbd:`Cmd` +:kbd:`0`
+     - :kbd:`Ctrl` + :kbd:`0`
+     - :kbd:`Cmd` + :kbd:`0`
 
    * - Menu
      - Zoom in
-     - :kbd:`Ctrl` +:kbd:`=`
-     - :kbd:`Cmd` +:kbd:`=`
+     - :kbd:`Ctrl` + :kbd:`=`
+     - :kbd:`Cmd` + :kbd:`=`
 
    * - Menu
      - Zoom out
-     - :kbd:`Ctrl` +:kbd:`-`
-     - :kbd:`Cmd` +:kbd:`-`
+     - :kbd:`Ctrl` + :kbd:`-`
+     - :kbd:`Cmd` + :kbd:`-`
 
    * - Menu
      - Toggle DevTools
-     - :kbd:`Alt` +:kbd:`Ctrl` +:kbd:`I`
-     - :kbd:`Alt` +:kbd:`Cmd` +:kbd:`I`
+     - :kbd:`Alt` + :kbd:`Ctrl` + :kbd:`I`
+     - :kbd:`Alt` + :kbd:`Cmd` + :kbd:`I`
 
    * - Menu
      - Minimize
-     - :kbd:`Ctrl` +:kbd:`M`
-     - :kbd:`Cmd` +:kbd:`M`
+     - :kbd:`Ctrl` + :kbd:`M`
+     - :kbd:`Cmd` + :kbd:`M`
 
    * - General
      - Undo
-     - :kbd:`Ctrl` +:kbd:`Z`
-     - :kbd:`Cmd` +:kbd:`Z`
+     - :kbd:`Ctrl` + :kbd:`Z`
+     - :kbd:`Cmd` + :kbd:`Z`
 
    * - General
      - Redo
-     - :kbd:`Ctrl` +:kbd:`Shift` +:kbd:`Z`
-     - :kbd:`Cmd` +:kbd:`Shift` +:kbd:`Z`
+     - :kbd:`Ctrl` + :kbd:`Shift` + :kbd:`Z`
+     - :kbd:`Cmd` + :kbd:`Shift` + :kbd:`Z`
 
    * - General
      - Cut
-     - :kbd:`Ctrl` +:kbd:`X`
-     - :kbd:`Cmd` +:kbd:`X`
+     - :kbd:`Ctrl` + :kbd:`X`
+     - :kbd:`Cmd` + :kbd:`X`
 
    * - General
      - Copy
-     - :kbd:`Ctrl` +:kbd:`C`
-     - :kbd:`Cmd` +:kbd:`C`
+     - :kbd:`Ctrl` + :kbd:`C`
+     - :kbd:`Cmd` + :kbd:`C`
 
    * - General
      - Paste
@@ -123,63 +123,63 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
 
    * - General
      - Select all
-     - :kbd:`Ctrl` +:kbd:`A`
-     - :kbd:`Cmd` +:kbd:`A`
+     - :kbd:`Ctrl` + :kbd:`A`
+     - :kbd:`Cmd` + :kbd:`A`
 
    * - General
      - Find
-     - :kbd:`Ctrl` +:kbd:`F`
-     - :kbd:`Cmd` +:kbd:`F`
+     - :kbd:`Ctrl` + :kbd:`F`
+     - :kbd:`Cmd` + :kbd:`F`
 
    * - Workspace
      - Navigate to next tab
-     - :kbd:`Ctrl` +:kbd:`Shift` +:kbd:`]`
-     - :kbd:`Cmd` +:kbd:`Shift` +:kbd:`]`
+     - :kbd:`Ctrl` + :kbd:`Shift` + :kbd:`]`
+     - :kbd:`Cmd` + :kbd:`Shift` + :kbd:`]`
 
    * - Workspace
      - Navigate to previous tab
-     - :kbd:`Ctrl` +:kbd:`Shift` +:kbd:`[`
-     - :kbd:`Cmd` +:kbd:`Shift` +:kbd:`[`
+     - :kbd:`Ctrl` + :kbd:`Shift` + :kbd:`[`
+     - :kbd:`Cmd` + :kbd:`Shift` + :kbd:`[`
 
    * - Workspace
      - Close current tab
-     - :kbd:`Ctrl` + :kbd:`Shift` +:kbd:`W`
-     - :kbd:`Cmd` + :kbd:`Shift` +:kbd:`W`
+     - :kbd:`Ctrl` + :kbd:`Shift` + :kbd:`W`
+     - :kbd:`Cmd` + :kbd:`Shift` + :kbd:`W`
 
    * - Workspace
      - Open new tab
-     - :kbd:`Ctrl` +:kbd:`T`
-     - :kbd:`Cmd` +:kbd:`T`
+     - :kbd:`Ctrl` + :kbd:`T`
+     - :kbd:`Cmd` + :kbd:`T`
 
    * - Aggregation Focus Mode
      - Add a new stage after current one
-     - :kbd:`Ctrl` +:kbd:`Shift` +:kbd:`B`
-     - :kbd:`Cmd` +:kbd:`Shift` +:kbd:`B`
+     - :kbd:`Ctrl` + :kbd:`Shift` + :kbd:`B`
+     - :kbd:`Cmd` + :kbd:`Shift` + :kbd:`B`
 
    * - Aggregation Focus Mode
      - Add a new stage before current one
-     - :kbd:`Ctrl` +:kbd:`Shift` +:kbd:`A`
-     - :kbd:`Cmd` +:kbd:`Shift` +:kbd:`A`
+     - :kbd:`Ctrl` + :kbd:`Shift` + :kbd:`A`
+     - :kbd:`Cmd` + :kbd:`Shift` + :kbd:`A`
 
    * - Aggregation Focus Mode
      - Navigate to next stage
-     - :kbd:`Ctrl` +:kbd:`Shift` +:kbd:`9`
-     - :kbd:`Cmd` +:kbd:`Shift` +:kbd:`9`
+     - :kbd:`Ctrl` + :kbd:`Shift` + :kbd:`9`
+     - :kbd:`Cmd` + :kbd:`Shift` + :kbd:`9`
 
    * - Aggregation Focus Mode
      - Navigate to previous stage
-     - :kbd:`Ctrl` +:kbd:`Shift` +:kbd:`0`
-     - :kbd:`Cmd` +:kbd:`Shift` +:kbd:`0`
+     - :kbd:`Ctrl` + :kbd:`Shift` + :kbd:`0`
+     - :kbd:`Cmd` + :kbd:`Shift` + :kbd:`0`
 
    * - Pipeline text editor
      - Comment out code
-     - :kbd:`Ctrl` +:kbd:`/`
-     - :kbd:`Cmd` +:kbd:`/`
+     - :kbd:`Ctrl` + :kbd:`/`
+     - :kbd:`Cmd` + :kbd:`/`
 
    * - All text editors
      - Prettify code
-     - :kbd:`Ctrl` +:kbd:`Shift` +:kbd:`B`
-     - :kbd:`Ctrl` +:kbd:`Shift` +:kbd:`B`
+     - :kbd:`Ctrl` + :kbd:`Shift` + :kbd:`B`
+     - :kbd:`Ctrl` + :kbd:`Shift` + :kbd:`B`
 
    * - Query bar
      - Submit query
@@ -188,38 +188,38 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
 
    * - Web Shell
      - Toggle shell
-     - :kbd:`Ctrl` +:kbd:``
-     - :kbd:`Ctrl` +:kbd:``
+     - :kbd:`Ctrl` + :kbd:``
+     - :kbd:`Ctrl` + :kbd:``
 
    * - Web Shell
      - Deletes the next character
-     - :kbd:`Ctrl` +:kbd:`D`
-     - :kbd:`Ctrl` +:kbd:`D`
+     - :kbd:`Ctrl` + :kbd:`D`
+     - :kbd:`Ctrl` + :kbd:`D`
 
    * - Web Shell
      - Moves the cursor to the end of the line
-     - :kbd:`Ctrl` +:kbd:`E`
-     - :kbd:`Ctrl` +:kbd:`E`
+     - :kbd:`Ctrl` + :kbd:`E`
+     - :kbd:`Ctrl` + :kbd:`E`
 
    * - Web Shell
      - Moves the cursor forward one character
-     - :kbd:`Ctrl` +:kbd:`F`
-     - :kbd:`Ctrl` +:kbd:`F`
+     - :kbd:`Ctrl` + :kbd:`F`
+     - :kbd:`Ctrl` + :kbd:`F`
 
    * - Web Shell
      - Erases one character, similar to hitting backspace
-     - :kbd:`Ctrl` +:kbd:`H`
-     - :kbd:`Cmd` +:kbd:`H`
+     - :kbd:`Ctrl` + :kbd:`H`
+     - :kbd:`Cmd` + :kbd:`H`
 
    * - Web Shell
      - Clears the screen, similar to the clear command
-     - :kbd:`Ctrl` +:kbd:`L`
-     - :kbd:`Cmd` +:kbd:`L`
+     - :kbd:`Ctrl` + :kbd:`L`
+     - :kbd:`Cmd` + :kbd:`L`
 
    * - Web Shell
      - Swap the last two characters before the cursor
-     - :kbd:`Ctrl` +:kbd:`T`
-     - :kbd:`Ctrl` +:kbd:`T`
+     - :kbd:`Ctrl` + :kbd:`T`
+     - :kbd:`Ctrl` + :kbd:`T`
 
    * - Web Shell
      - Cycle backwards through command history

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -188,8 +188,8 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
 
    * - Web Shell
      - Toggle shell
-     - :kbd:`Ctrl` + :kbd:` ` `
-     - :kbd:`Ctrl` + :kbd:` ` `
+     - :kbd:`Ctrl` + :kbd:` ``` `
+     - :kbd:`Ctrl` + :kbd:` ``` `
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -2,8 +2,6 @@
 Keyboard Shortcuts
 ==================
 
-.. |placeholder| replace:: ``
-
 .. contents:: On this page
    :local:
    :backlinks: none
@@ -188,8 +186,8 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
 
    * - Web Shell
      - Toggle shell
-     - :kbd:`Ctrl` + :kbd:`|placeholder|` + `````
-     - :kbd:`Ctrl` + :kbd:`|placeholder|` + `````
+     - :kbd:`Ctrl` + `````
+     - :kbd:`Ctrl` + :kbd:`````
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -189,7 +189,7 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
    * - Web Shell
      - Toggle shell
      - :kbd:`Ctrl` + `````
-     - :kbd:`Ctrl` +  :kbd:`̀`
+     - :kbd:`Ctrl` +  :kbd:` `̀  `
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -2,7 +2,7 @@
 Keyboard Shortcuts
 ==================
 
-.. |x| replace:: ``x``
+.. |x| replace:: kbd:``
 
 .. contents:: On this page
    :local:
@@ -189,7 +189,7 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
    * - Web Shell
      - Toggle shell
      - :kbd:`Ctrl` + `````
-     - :kbd:`Ctrl` + :kbd:`|x|`
+     - :kbd:`Ctrl` + |x|`
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -187,7 +187,7 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
    * - Web Shell
      - Toggle shell
      - :kbd:`Ctrl` + `````
-     - :kbd:`Ctrl` + :kbd:`````
+     - :kbd:`Ctrl` + :kbd:``````
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -23,210 +23,210 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
 
    * - Menu
      - Online help
-     - ``F1``
-     - ``F1``
+     -:kdb:`F1`
+     -:kdb:`F1`
 
    * - Menu
      - Quit application
-     - ``Ctrl`` + ``Q``
-     - ``Cmd`` + ``Q``
+     -:kdb:`Ctrl` +:kdb:`Q`
+     -:kdb:`Cmd` +:kdb:`Q`
 
    * - Menu
      - Show settings
-     - ``Ctrl`` + ``,``
-     - ``Cmd`` + ``,``
+     -:kdb:`Ctrl` +:kdb:`,`
+     -:kdb:`Cmd` +:kdb:`,`
 
    * - Menu
      - Hide window
-     - ``Ctrl`` + ``H``
-     - ``Cmd`` + ``H``
+     -:kdb:`Ctrl` +:kdb:`H`
+     -:kdb:`Cmd` +:kdb:`H`
 
    * - Menu
      - Hide other windows
-     - ``Ctrl`` + ``Shift`` + ``H``
-     - ``Cmd`` + ``Shift`` + ``H``
+     -:kdb:`Ctrl` +:kdb:`Shift` +:kdb:`H`
+     -:kdb:`Cmd` +:kdb:`Shift` +:kdb:`H`
 
    * - Menu
      - Open a new Compass window
-     - ``Ctrl`` + ``N``
-     - ``Cmd`` + ``N``
+     -:kdb:`Ctrl` +:kdb:`N`
+     -:kdb:`Cmd` +:kdb:`N`
 
    * - Menu
      - Share schema as JSON
-     - ``Alt`` + ``Ctrl`` + ``S``
-     - ``Alt`` + ``Cmd`` + ``S``
+     -:kdb:`Alt` +:kdb:`Ctrl` +:kdb:`S`
+     -:kdb:`Alt` +:kdb:`Cmd` +:kdb:`S`
 
    * - Menu
      - Reload screen
-     - ``Ctrl`` + ``Shift`` + ``R``
-     - ``Cmd`` + ``Shift`` + ``R``
+     -:kdb:`Ctrl` +:kdb:`Shift` +:kdb:`R`
+     -:kdb:`Cmd` +:kdb:`Shift` +:kdb:`R`
 
    * - Menu
      - Reload data
-     - ``Ctrl`` + ``R``
-     - ``Cmd`` + ``R``
+     -:kdb:`Ctrl` +:kdb:`R`
+     -:kdb:`Cmd` +:kdb:`R`
 
    * - Menu
      - Toggle sidebar
-     - ``Ctrl`` + ``Shift`` + ``D``
-     - ``Cmd`` + ``Shift`` + ``D``
+     -:kdb:`Ctrl` +:kdb:`Shift` +:kdb:`D`
+     -:kdb:`Cmd` +:kdb:`Shift` +:kdb:`D`
 
    * - Menu
      - Actual size
-     - ``Ctrl`` + ``0``
-     - ``Cmd`` + ``0``
+     -:kdb:`Ctrl` +:kdb:`0`
+     -:kdb:`Cmd` +:kdb:`0`
 
    * - Menu
      - Zoom in
-     - ``Ctrl`` + ``=``
-     - ``Cmd`` + ``=``
+     -:kdb:`Ctrl` +:kdb:`=`
+     -:kdb:`Cmd` +:kdb:`=`
 
    * - Menu
      - Zoom out
-     - ``Ctrl`` + ``-``
-     - ``Cmd`` + ``-``
+     -:kdb:`Ctrl` +:kdb:`-`
+     -:kdb:`Cmd` +:kdb:`-`
 
    * - Menu
      - Toggle DevTools
-     - ``Alt`` + ``Ctrl`` + ``I``
-     - ``Alt`` + ``Cmd`` + ``I``
+     -:kdb:`Alt` +:kdb:`Ctrl` +:kdb:`I`
+     -:kdb:`Alt` +:kdb:`Cmd` +:kdb:`I`
 
    * - Menu
      - Minimize
-     - ``Ctrl`` + ``M``
-     - ``Cmd`` + ``M``
+     -:kdb:`Ctrl` +:kdb:`M`
+     -:kdb:`Cmd` +:kdb:`M`
 
    * - General
      - Undo
-     - ``Ctrl`` + ``Z``
-     - ``Cmd`` + ``Z``
+     -:kdb:`Ctrl` +:kdb:`Z`
+     -:kdb:`Cmd` +:kdb:`Z`
 
    * - General
      - Redo
-     - ``Ctrl`` + ``Shift`` + ``Z``
-     - ``Cmd`` + ``Shift`` + ``Z``
+     -:kdb:`Ctrl` +:kdb:`Shift` +:kdb:`Z`
+     -:kdb:`Cmd` +:kdb:`Shift` +:kdb:`Z`
 
    * - General
      - Cut
-     - ``Ctrl`` + ``X``
-     - ``Cmd`` + ``X``
+     -:kdb:`Ctrl` +:kdb:`X`
+     -:kdb:`Cmd` +:kdb:`X`
 
    * - General
      - Copy
-     - ``Ctrl`` + ``C``
-     - ``Cmd`` + ``C``
+     -:kdb:`Ctrl` +:kdb:`C`
+     -:kdb:`Cmd` +:kdb:`C`
 
    * - General
      - Paste
-     - ``Ctrl + V``
-     - ``Cmd + V``
+     -:kdb:`Ctrl + V`
+     -:kdb:`Cmd + V`
 
    * - General
      - Select all
-     - ``Ctrl`` + ``A``
-     - ``Cmd`` + ``A``
+     -:kdb:`Ctrl` +:kdb:`A`
+     -:kdb:`Cmd` +:kdb:`A`
 
    * - General
      - Find
-     - ``Ctrl`` + ``F``
-     - ``Cmd`` + ``F``
+     -:kdb:`Ctrl` +:kdb:`F`
+     -:kdb:`Cmd` +:kdb:`F`
 
    * - Workspace
      - Navigate to next tab
-     - ``Ctrl`` + ``Shift`` + ``]``
-     - ``Cmd`` + ``Shift`` + ``]``
+     -:kdb:`Ctrl` +:kdb:`Shift` +:kdb:`]`
+     -:kdb:`Cmd` +:kdb:`Shift` +:kdb:`]`
 
    * - Workspace
      - Navigate to previous tab
-     - ``Ctrl`` + ``Shift`` + ``[``
-     - ``Cmd`` + ``Shift`` + ``[``
+     -:kdb:`Ctrl` +:kdb:`Shift` +:kdb:`[`
+     -:kdb:`Cmd` +:kdb:`Shift` +:kdb:`[`
 
    * - Workspace
      - Close current tab
-     - ``Ctrl`` + ``W``
-     - ``Cmd`` + ``W``
+     -:kdb:`Ctrl` + :kdb:`Shift` +:kdb:`W`
+     -:kdb:`Cmd` + :kdb:`Shift` +:kdb:`W`
 
    * - Workspace
      - Open new tab
-     - ``Ctrl`` + ``T``
-     - ``Cmd`` + ``T``
+     -:kdb:`Ctrl` +:kdb:`T`
+     -:kdb:`Cmd` +:kdb:`T`
 
    * - Aggregation Focus Mode
      - Add a new stage after current one
-     - ``Ctrl`` + ``Shift`` + ``B``
-     - ``Cmd`` + ``Shift`` + ``B``
+     -:kdb:`Ctrl` +:kdb:`Shift` +:kdb:`B`
+     -:kdb:`Cmd` +:kdb:`Shift` +:kdb:`B`
 
    * - Aggregation Focus Mode
      - Add a new stage before current one
-     - ``Ctrl`` + ``Shift`` + ``A``
-     - ``Cmd`` + ``Shift`` + ``A``
+     -:kdb:`Ctrl` +:kdb:`Shift` +:kdb:`A`
+     -:kdb:`Cmd` +:kdb:`Shift` +:kdb:`A`
 
    * - Aggregation Focus Mode
      - Navigate to next stage
-     - ``Ctrl`` + ``Shift`` + ``9``
-     - ``Cmd`` + ``Shift`` + ``9``
+     -:kdb:`Ctrl` +:kdb:`Shift` +:kdb:`9`
+     -:kdb:`Cmd` +:kdb:`Shift` +:kdb:`9`
 
    * - Aggregation Focus Mode
      - Navigate to previous stage
-     - ``Ctrl`` + ``Shift`` + ``0``
-     - ``Cmd`` + ``Shift`` + ``0``
+     -:kdb:`Ctrl` +:kdb:`Shift` +:kdb:`0`
+     -:kdb:`Cmd` +:kdb:`Shift` +:kdb:`0`
 
    * - Pipeline text editor
      - Comment out code
-     - ``Ctrl`` + ``/``
-     - ``Cmd`` + ``/``
+     -:kdb:`Ctrl` +:kdb:`/`
+     -:kdb:`Cmd` +:kdb:`/`
 
    * - All text editors
      - Prettify code
-     - ``Ctrl`` + ``Shift`` + ``B``
-     - ``Ctrl`` + ``Shift`` + ``B``
+     -:kdb:`Ctrl` +:kdb:`Shift` +:kdb:`B`
+     -:kdb:`Ctrl` +:kdb:`Shift` +:kdb:`B`
 
    * - Query bar
      - Submit query
-     - ``Enter (from the query bar)``
-     - ``Enter (from the query bar)``
+     -:kdb:`Enter (from the query bar)`
+     -:kdb:`Enter (from the query bar)`
 
    * - Web Shell
      - Toggle shell
-     - ``Ctrl`` + `````
-     - ``Ctrl`` + `````
+     -:kdb:`Ctrl` +:kdb:``
+     -:kdb:`Ctrl` +:kdb:``
 
    * - Web Shell
      - Deletes the next character
-     - ``Ctrl`` + ``D``
-     - ``Ctrl`` + ``D``
+     -:kdb:`Ctrl` +:kdb:`D`
+     -:kdb:`Ctrl` +:kdb:`D`
 
    * - Web Shell
      - Moves the cursor to the end of the line
-     - ``Ctrl`` + ``E``
-     - ``Ctrl`` + ``E``
+     -:kdb:`Ctrl` +:kdb:`E`
+     -:kdb:`Ctrl` +:kdb:`E`
 
    * - Web Shell
      - Moves the cursor forward one character
-     - ``Ctrl`` + ``F``
-     - ``Ctrl`` + ``F``
+     -:kdb:`Ctrl` +:kdb:`F`
+     -:kdb:`Ctrl` +:kdb:`F`
 
    * - Web Shell
      - Erases one character, similar to hitting backspace
-     - ``Ctrl`` + ``H``
-     - ``Cmd`` + ``H``
+     -:kdb:`Ctrl` +:kdb:`H`
+     -:kdb:`Cmd` +:kdb:`H`
 
    * - Web Shell
      - Clears the screen, similar to the clear command
-     - ``Ctrl`` + ``L``
-     - ``Cmd`` + ``L``
+     -:kdb:`Ctrl` +:kdb:`L`
+     -:kdb:`Cmd` +:kdb:`L`
 
    * - Web Shell
      - Swap the last two characters before the cursor
-     - ``Ctrl`` + ``T``
-     - ``Ctrl`` + ``T``
+     -:kdb:`Ctrl` +:kdb:`T`
+     -:kdb:`Ctrl` +:kdb:`T`
 
    * - Web Shell
      - Cycle backwards through command history
-     - ``↑``
-     - ``↑``
+     -:kdb:`↑`
+     -:kdb:`↑`
 
    * - Web Shell
      - Cycle forwards through command history
-     - ``↓``
-     - ``↓``
+     -:kdb:`↓`
+     -:kdb:`↓`

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -187,7 +187,7 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
    * - Web Shell
      - Toggle shell
      - :kbd:`Ctrl` + `````
-     - :kbd:`Ctrl` + :kbd:``````
+     - :kbd:`Ctrl` + :kbd:`|tickmark|`
 
    * - Web Shell
      - Deletes the next character

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -188,7 +188,7 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
 
    * - Web Shell
      - Toggle shell
-     - :kbd:`Ctrl` + `````
+     - :kbd:`Ctrl` + :kbd:`ˋ`
      - :kbd:`Ctrl` +  :kbd:`̀`
 
    * - Web Shell

--- a/source/keyboard-shortcuts.txt
+++ b/source/keyboard-shortcuts.txt
@@ -189,7 +189,7 @@ Keyboard shortcuts enable you to easily navigate |compass-short|.
    * - Web Shell
      - Toggle shell
      - :kbd:`Ctrl` + `````
-     - :kbd:`Ctrl` + |x|`
+     - :kbd:`Ctrl` + |x|
 
    * - Web Shell
      - Deletes the next character

--- a/source/settings/settings-reference.txt
+++ b/source/settings/settings-reference.txt
@@ -109,7 +109,7 @@ You can configure the following settings on the |compass| interface:
 
    * - Show Quit Confirmation Dialog
      - General
-     - Toggle whether a confirmation dialog shows when quitting Compass.
+     - Specify whether a confirmation dialog shows when quitting Compass.
        You can also check the ``Do not ask again`` checkbox on the quit 
        dialog to disable this setting.
 

--- a/source/settings/settings-reference.txt
+++ b/source/settings/settings-reference.txt
@@ -112,8 +112,8 @@ You can configure the following settings on the |compass| interface:
      - Toggle whether a confirmation dialog is shown when quitting Compass.
        You can also toggle this setting with the keyboard shortcut 
        :kbd:`ctrl` + :kbd:`Q` on Windows or :kbd:`cmd` + :kbd:`Q` on MacOS.
-       To avoid seeing the dialog on when quitting Compass, check the  
-       `Do not ask again` checkbox.
+       To avoid seeing the dialog when quitting Compass, check the  
+       ``Do not ask again`` checkbox.
 
    * - Sync with OS
      - Theme 

--- a/source/settings/settings-reference.txt
+++ b/source/settings/settings-reference.txt
@@ -110,10 +110,11 @@ You can configure the following settings on the |compass| interface:
    * - Show Quit Confirmation Dialog
      - General
      - Toggle whether a confirmation dialog is shown when quitting Compass.
-       You can also toggle this setting with the keyboard shortcut 
-       :kbd:`ctrl` + :kbd:`Q` on Windows or :kbd:`cmd` + :kbd:`Q` on MacOS.
        Checking the ``Do not ask again`` checkbox on the quit dialog 
        disables this setting.
+
+       You can also toggle the quit dialog with the keyboard shortcut:
+       :kbd:`ctrl` + :kbd:`Q` on Windows or :kbd:`cmd` + :kbd:`Q` on MacOS.
 
    * - Sync with OS
      - Theme 

--- a/source/settings/settings-reference.txt
+++ b/source/settings/settings-reference.txt
@@ -112,8 +112,8 @@ You can configure the following settings on the |compass| interface:
      - Toggle whether a confirmation dialog is shown when quitting Compass.
        You can also toggle this setting with the keyboard shortcut 
        :kbd:`ctrl` + :kbd:`Q` on Windows or :kbd:`cmd` + :kbd:`Q` on MacOS.
-       To avoid seeing the dialog when quitting Compass, check the  
-       ``Do not ask again`` checkbox.
+       To avoid seeing the dialog when quitting Compass, you can also 
+       check the ``Do not ask again`` checkbox.
 
    * - Sync with OS
      - Theme 

--- a/source/settings/settings-reference.txt
+++ b/source/settings/settings-reference.txt
@@ -107,6 +107,14 @@ You can configure the following settings on the |compass| interface:
        enabled. You cannot toggle this option on Linux. You can toggle this 
        setting only on Windows or macOS.
 
+   * - Show Quit Confirmation Dialog
+     - General
+     - Toggle whether a confirmation dialog is shown when quitting Compass.
+       You can also toggle this setting with the keyboard shortcut 
+       :kbd:`ctrl` + :kbd:`Q` on Windows or :kbd:`cmd` + :kbd:`Q` on MacOS.
+       To avoid seeing the dialog on when quitting Compass, check the  
+       `Do not ask again` checkbox.
+
    * - Sync with OS
      - Theme 
      - Automatically switch between light and dark themes based on your OS 

--- a/source/settings/settings-reference.txt
+++ b/source/settings/settings-reference.txt
@@ -110,8 +110,8 @@ You can configure the following settings on the |compass| interface:
    * - Show Quit Confirmation Dialog
      - General
      - Toggle whether a confirmation dialog is shown when quitting Compass.
-       Checking the ``Do not ask again`` checkbox on the quit dialog 
-       disables this setting.
+       You can also check the ``Do not ask again`` checkbox on the quit 
+       dialog to disable this setting.
 
        You can also toggle the quit dialog with the keyboard shortcut:
        :kbd:`ctrl` + :kbd:`Q` on Windows or :kbd:`cmd` + :kbd:`Q` on Mac.

--- a/source/settings/settings-reference.txt
+++ b/source/settings/settings-reference.txt
@@ -113,8 +113,9 @@ You can configure the following settings on the |compass| interface:
        You can also check the ``Do not ask again`` checkbox on the quit 
        dialog to disable this setting.
 
-       The quit dialog is also shown when quitting with the keyboard shortcut:
-       :kbd:`ctrl` + :kbd:`Q` on Windows or :kbd:`cmd` + :kbd:`Q` on Mac.
+       The quit dialog is also shown when quitting with the keyboard 
+       shortcut::kbd:`ctrl` + :kbd:`Q` on Windows 
+       or :kbd:`cmd` + :kbd:`Q` on Mac.
 
    * - Sync with OS
      - Theme 

--- a/source/settings/settings-reference.txt
+++ b/source/settings/settings-reference.txt
@@ -113,7 +113,7 @@ You can configure the following settings on the |compass| interface:
        You can also check the ``Do not ask again`` checkbox on the quit 
        dialog to disable this setting.
 
-       You can also toggle the quit dialog with the keyboard shortcut:
+       The quit dialog is also shown when quitting with the keyboard shortcut:
        :kbd:`ctrl` + :kbd:`Q` on Windows or :kbd:`cmd` + :kbd:`Q` on Mac.
 
    * - Sync with OS

--- a/source/settings/settings-reference.txt
+++ b/source/settings/settings-reference.txt
@@ -109,7 +109,7 @@ You can configure the following settings on the |compass| interface:
 
    * - Show Quit Confirmation Dialog
      - General
-     - Toggle whether a confirmation dialog is shown when quitting Compass.
+     - Toggle whether a confirmation dialog shows when quitting Compass.
        You can also check the ``Do not ask again`` checkbox on the quit 
        dialog to disable this setting.
 

--- a/source/settings/settings-reference.txt
+++ b/source/settings/settings-reference.txt
@@ -112,8 +112,8 @@ You can configure the following settings on the |compass| interface:
      - Toggle whether a confirmation dialog is shown when quitting Compass.
        You can also toggle this setting with the keyboard shortcut 
        :kbd:`ctrl` + :kbd:`Q` on Windows or :kbd:`cmd` + :kbd:`Q` on MacOS.
-       To avoid seeing the dialog when quitting Compass, you can also 
-       check the ``Do not ask again`` checkbox.
+       Checking the ``Do not ask again`` checkbox on the quit dialog 
+       disables this setting.
 
    * - Sync with OS
      - Theme 

--- a/source/settings/settings-reference.txt
+++ b/source/settings/settings-reference.txt
@@ -114,7 +114,7 @@ You can configure the following settings on the |compass| interface:
        disables this setting.
 
        You can also toggle the quit dialog with the keyboard shortcut:
-       :kbd:`ctrl` + :kbd:`Q` on Windows or :kbd:`cmd` + :kbd:`Q` on MacOS.
+       :kbd:`ctrl` + :kbd:`Q` on Windows or :kbd:`cmd` + :kbd:`Q` on Mac.
 
    * - Sync with OS
      - Theme 


### PR DESCRIPTION
## DESCRIPTION

- Add quit setting to the settings page.
- Updated all keyboard short cuts to use `:kbd:` role.
- Updated the close window hotkey to be cmd + shift + w to reflect recent app change.
- Add ref to the keyboard shortcuts page.

## STAGING

https://preview-mongodbianfmongodb.gatsbyjs.io/compass/DOCSP-40542/settings/settings-reference/#settings

https://preview-mongodbianfmongodb.gatsbyjs.io/compass/DOCSP-40542/keyboard-shortcuts/

## JIRA

https://jira.mongodb.org/browse/DOCSP-40542

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6684128efe162e50061300a9

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)