### PR TITLE
DOCSP-40984 auth connection page typo

### DIFF
--- a/source/connect/advanced-connection-options/authentication-connection.txt
+++ b/source/connect/advanced-connection-options/authentication-connection.txt
@@ -159,7 +159,7 @@ Procedure
 
          * - (Optional) Service Name
            - Every MongoDB :binary:`mongod` and :binary:`mongos` instance 
-             (or exe or exe on Windows) must have an associated service name. The 
+             (or ``mongod.exe`` and ``mongos.exe`` on Windows) must have an associated service name. The 
              default is ``mongodb``. 
 
          * - (Optional) Canonicalize Host Name


### PR DESCRIPTION
## DESCRIPTION

Fixes typo on compass authentication connection page.


## STAGING

https://preview-mongodbjmdmongo.gatsbyjs.io/compass/DOCSP-40984/connect/advanced-connection-options/authentication-connection/#kerberos

## JIRA

https://jira.mongodb.org/browse/DOCSP-40984

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=667ed6d6fe162e5006082ba7

## Self-Review Checklist

- [X] Is this free of any warnings or errors in the RST?
- [X] Is this free of spelling errors?
- [X] Is this free of grammatical errors?
- [X] Is this free of staging / rendering issues?
- [X] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)