### PR TITLE
DOCSP-40217 -- Remove reference to shared tier clusters in indexes limitations

### DIFF
--- a/source/indexes.txt
+++ b/source/indexes.txt
@@ -158,6 +158,7 @@ index.
       |compass-short| removes the :guilabel:`Hidden` badge from the 
       :guilabel:`Properties` column.
 
+
 .. _drop-index:
 
 Drop an Index

--- a/source/indexes.txt
+++ b/source/indexes.txt
@@ -179,8 +179,7 @@ Limitations
   
   .. tip::
 
-     For clusters running an earlier version of MongoDB or 
-     :ref:`shared tier clusters <shared-tier-cluster>`, 
+     For clusters running an earlier version of MongoDB, 
      you can manage your Atlas Search indexes using the Atlas UI, the 
      :ref:`Atlas CLI <atlas-cli>`, or the 
      :ref:`Atlas Administration API <atlas-admin-api>`. 


### PR DESCRIPTION
## DESCRIPTION
Remove reference to shared tier clusters in indexes limitations.


## STAGING
https://preview-mongodbjvincentmongodb.gatsbyjs.io/compass/DOCSP-40217/indexes/#limitations


## JIRA
https://jira.mongodb.org/browse/DOCSP-40217

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=667f271dfe162e50062b3e9a

## Self-Review Checklist

- [X] Is this free of any warnings or errors in the RST?
- [X] Is this free of spelling errors?
- [X] Is this free of grammatical errors?
- [X] Is this free of staging / rendering issues?
- [X] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)