### PR TITLE
DOCSP-41463 Compass Atlas Vector Search Index updates

### DIFF
--- a/source/indexes/create-vector-search-index.txt
+++ b/source/indexes/create-vector-search-index.txt
@@ -66,9 +66,9 @@ Steps
 
          * - ``type``
            - string
-           - Human-readable label that identifies the type of index. Value must 
+           - Human-readable label that identifies the type of index. The value must 
              be ``vector`` to perform vector search against the indexed fields. If 
-             omitted, defaults to ``search``, which only supports full-text search.
+             omitted, it defaults to ``search``, which only supports full-text search.
 
          * - ``path``
            - string

--- a/source/indexes/create-vector-search-index.txt
+++ b/source/indexes/create-vector-search-index.txt
@@ -71,7 +71,7 @@ Steps
          * - ``numDimensions``
            - int 
            - The number of vector dimensions, which Atlas Search enforces at index- and 
-             query-time. This value can't be greater than 2048.
+             query-time. This value can't be greater than 4096.
         
          * - ``similarity``
            - string

--- a/source/indexes/create-vector-search-index.txt
+++ b/source/indexes/create-vector-search-index.txt
@@ -64,6 +64,12 @@ Steps
            - Type
            - Description
 
+         * - ``type``
+           - string
+           - Human-readable label that identifies the type of index. Value must 
+             be ``vector`` to perform vector search against the indexed fields. If 
+             omitted, defaults to ``search``, which only supports full-text search.
+
          * - ``path``
            - string
            - The field name to index.
@@ -72,7 +78,7 @@ Steps
            - int 
            - The number of vector dimensions, which Atlas Search enforces at index- and 
              query-time. This value can't be greater than 4096.
-        
+
          * - ``similarity``
            - string
            - The vector similarity function used to search for the top K-nearest neighbors.

--- a/source/indexes/create-vector-search-index.txt
+++ b/source/indexes/create-vector-search-index.txt
@@ -67,7 +67,7 @@ Steps
          * - ``type``
            - string
            - Human-readable label that identifies the type of index. The value must 
-             be ``vector`` to perform vector search against the indexed fields. If 
+             be ``vector`` to perform a vector search against the indexed fields. If 
              omitted, it defaults to ``search``, which only supports full-text search.
 
          * - ``path``


### PR DESCRIPTION
## DESCRIPTION
Compass Atlas Vector Search Index updates. 

After discussion with engineering, the compass docs needed the update on the value for the ``numDimensions`` field but the example feedback on the jira ticket does not apply to the compass example.

## STAGING
https://preview-mongodbjocelynmendez1.gatsbyjs.io/compass/DOCSP-41463/indexes/create-vector-search-index/#provide-the-atlas-vector-search-index-configurations

## JIRA
https://jira.mongodb.org/browse/DOCSP-41463

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66993b1a26eba79552154583

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)