### PR TITLE
DOCSP-44185-cmd-line-options-redirect

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -13,3 +13,6 @@ raw: docs/compass/ -> ${base}/current/
 [*]: docs/compass/${version}/query/favorite/ -> ${base}/current/query/queries/
 [*]: docs/compass/${version}/import-pipeline-from-text/ -> ${base}/current/create-agg-pipeline/
 [*]: docs/compass/${version}/export-pipeline-to-language/ -> ${base}/current/agg-pipeline-builder/export-pipeline-to-language/
+
+# DOCSP-44185 - Cmd line options redirect
+[*]: docs/compass/${version}/command-line-options/ -> ${base}/current/settings/command-line-options/


### PR DESCRIPTION
## DESCRIPTION

Add redirect to new command line options page. Newly added redirects from `mut-redirects` output:

```
Redirect 301 /docs/compass/master/command-line-options/ https://www.mongodb.com/docs/compass/current/settings/command-line-options/
Redirect 301 /docs/compass/beta/command-line-options/ https://www.mongodb.com/docs/compass/current/settings/command-line-options/
Redirect 301 /docs/compass/current/command-line-options/ https://www.mongodb.com/docs/compass/current/settings/command-line-options/
```

## STAGING

N/A

## JIRA

https://jira.mongodb.org/browse/DOCSP-44185

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)