### PR TITLE
DOCSP-44413-enabling-Chrome-DevTools-Compass-typo

### DIFF
--- a/source/settings/enable-dev-tools.txt
+++ b/source/settings/enable-dev-tools.txt
@@ -21,16 +21,21 @@ About This Task
 
 By default, |compass-short| disables :guilabel:`Chrome DevTools`.
 
+Before you Begin
+----------------
+
+To use Chrome DevTools on |compass-short|, you must enable the 
+:guilabel:`Enable MongoDB Shell` option.
+
 If you enable any of the following options, you cannot enable the 
 :guilabel:`Enable DevTools` setting: 
 
 - :guilabel:`Set Read-Only Mode`
-- :guilabel:`Enable MongoDB Shell`
 - :guilabel:`maxTimeMS`
 - :guilabel:`Protect Connection String Secrets`
 
-Procedure
----------
+Steps
+-----
 
 You can set the ``enableDevTools`` option in either: 
 


### PR DESCRIPTION
## DESCRIPTION
The `About this Task` section specifies four options that cannot be enabled if you want to use Chrome DevTools. One of those options is actually a requirement, while the others remain accurate.

Added a prerequisites section, containing a new line highlighting the enabled option requirement and moved the existing disabled option requirements beneath. I also renamed `Procedure` to `Steps`, as I was already updating from our task template.

## STAGING
[Toggle Chrome DevTools](https://deploy-preview-682--docs-compass.netlify.app/settings/enable-dev-tools/#about-this-task)

## JIRA
https://jira.mongodb.org/browse/DOCSP-44413

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)