### PR TITLE
DOCSP-44725-data-lake-limitation-to-data-federation

### DIFF
--- a/source/validation.txt
+++ b/source/validation.txt
@@ -193,7 +193,7 @@ Limitations
 -----------
 
 The :guilabel:`Validation` tab is not available if you are connected to
-a :atlas:`Data Lake </data-lake>`.
+:atlas:`Atlas Data Federation </data-federation>`.
 
 In :guilabel:`MongoDB Compass Readonly Edition`, you can
 only view validation rules. Creating and editing validation rules


### PR DESCRIPTION
## DESCRIPTION
This PR changes the Data Lake limitation under Limitations on [the Validations page](https://www.mongodb.com/docs/compass/current/validation/#limitations) for Compass so that it now instead references [Atlas Data Federation](https://www.mongodb.com/docs/atlas/data-federation/), as Atlas Data Lake is now named Atlas Data Federation. 

## STAGING
https://deploy-preview-689--docs-compass.netlify.app/validation/#limitations

## JIRA
https://jira.mongodb.org/browse/DOCSP-44725

## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)