### PR TITLE
DOCSP-44882 Compass AI Settings

### DIFF
--- a/source/settings/command-line-options.txt
+++ b/source/settings/command-line-options.txt
@@ -120,10 +120,13 @@ value in the :guilabel:`Settings` panel.
      - Allow |compass-short| to use generative AI for natural language querying.
        This feature requires an Atlas login and a deployed Atlas cluster.
 
-   * - .. option:: --enableGenAIDocumentPassing
+   * - .. option:: --enableGenAISampleDocumentPassing
      - Allow |compass| to send sample field values with query and
        aggregation generation requests. These values can improve
        the results from the AI.
+
+       This option implicitly sets the :option:`--enableGenAIFeatures`
+       option.
 
    * - .. option:: --enableMaps
      - Allow |compass| to make requests to a 3rd party mapping service. Use 

--- a/source/settings/command-line-options.txt
+++ b/source/settings/command-line-options.txt
@@ -116,6 +116,15 @@ value in the :guilabel:`Settings` panel.
        
        To learn more, see :ref:`compass-enable-dev-tools`.
 
+   * - .. option:: --enableGenAIFeatures
+     - Allow |compass-short| to use generative AI for natural language querying.
+       This feature requires an Atlas login and a deployed Atlas cluster.
+
+   * - .. option:: --enableGenAIDocumentPassing
+     - Allow |compass| to send sample field values with query and
+       aggregation generation requests. These values can improve
+       the results from the AI.
+
    * - .. option:: --enableMaps
      - Allow |compass| to make requests to a 3rd party mapping service. Use 
        ``--no-enableMaps`` to disable mapping requests.

--- a/source/settings/command-line-options.txt
+++ b/source/settings/command-line-options.txt
@@ -125,8 +125,8 @@ value in the :guilabel:`Settings` panel.
        aggregation generation requests. These values can improve
        the results from the AI.
 
-       If set, this option implicitly sets the
-       :option:`--enableGenAIFeatures` option.
+       If ``true``, this option implicitly sets the
+       :option:`--enableGenAIFeatures` option to ``true``.
 
    * - .. option:: --enableMaps
      - Allow |compass| to make requests to a 3rd party mapping service. Use 

--- a/source/settings/command-line-options.txt
+++ b/source/settings/command-line-options.txt
@@ -125,8 +125,8 @@ value in the :guilabel:`Settings` panel.
        aggregation generation requests. These values can improve
        the results from the AI.
 
-       This option implicitly sets the :option:`--enableGenAIFeatures`
-       option.
+       If set, this option implicitly sets the
+       :option:`--enableGenAIFeatures` option.
 
    * - .. option:: --enableMaps
      - Allow |compass| to make requests to a 3rd party mapping service. Use 

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -74,8 +74,8 @@ Settings
        aggregation generation requests. These values can improve
        the results from the AI.
 
-       This setting implicitly sets the ``enableGenAIFeatures``
-       setting.
+       When the ``enableGenAIFeatures`` setting is not set to
+       ``false``, this setting implicitly sets it to ``true``.
 
    * - :ref:`enableDevTools <compass-enable-dev-tools>`
      - Enable Chrome DevTools in |compass-short|.

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -74,8 +74,9 @@ Settings
        aggregation generation requests. These values can improve
        the results from the AI.
 
-       When the ``enableGenAIFeatures`` setting is not set to
-       ``false``, this setting implicitly sets it to ``true``.
+       This setting implicitly sets the ``enableGenAIFeatures``
+       setting to ``true``. If you don't want this setting
+       enabled, set ``enableGenAIFeatures`` to ``false``.
 
    * - :ref:`enableDevTools <compass-enable-dev-tools>`
      - Enable Chrome DevTools in |compass-short|.

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -69,6 +69,11 @@ Settings
      - Allow |compass-short| to use generative AI for natural language querying.
        This feature requires an Atlas login and a deployed Atlas cluster.
 
+   * - enableGenAIDocumentPassing
+     - Allow |compass| to send sample field values with query and
+       aggregation generation requests. These values can improve
+       the results from the AI.
+
    * - :ref:`enableDevTools <compass-enable-dev-tools>`
      - Enable Chrome DevTools in |compass-short|.
 

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -69,10 +69,13 @@ Settings
      - Allow |compass-short| to use generative AI for natural language querying.
        This feature requires an Atlas login and a deployed Atlas cluster.
 
-   * - enableGenAIDocumentPassing
+   * - enableGenAISampleDocumentPassing
      - Allow |compass| to send sample field values with query and
        aggregation generation requests. These values can improve
        the results from the AI.
+
+       This setting implicitly sets the ``enableGenAIFeatures``
+       setting.
 
    * - :ref:`enableDevTools <compass-enable-dev-tools>`
      - Enable Chrome DevTools in |compass-short|.

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -74,10 +74,10 @@ Settings
        aggregation generation requests. These values can improve
        the results from the AI.
 
-       This setting implicitly sets the ``enableGenAIFeatures``
-       setting to ``true``. If you don't want this setting
-       enabled, you must explicitly set ``enableGenAIFeatures``
-       to ``false``.
+       If ``true``, this setting implicitly sets the
+       ``enableGenAIFeatures`` setting to ``true``. If you don't
+       want this setting enabled, you must explicitly set
+       ``enableGenAIFeatures`` to ``false``.
 
    * - :ref:`enableDevTools <compass-enable-dev-tools>`
      - Enable Chrome DevTools in |compass-short|.

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -75,9 +75,7 @@ Settings
        the results from the AI.
 
        If ``true``, this setting implicitly sets the
-       ``enableGenAIFeatures`` setting to ``true``. If you don't
-       want this setting enabled, you must explicitly set
-       ``enableGenAIFeatures`` to ``false``.
+       ``enableGenAIFeatures`` setting to ``true``. 
 
    * - :ref:`enableDevTools <compass-enable-dev-tools>`
      - Enable Chrome DevTools in |compass-short|.

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -76,7 +76,8 @@ Settings
 
        This setting implicitly sets the ``enableGenAIFeatures``
        setting to ``true``. If you don't want this setting
-       enabled, set ``enableGenAIFeatures`` to ``false``.
+       enabled, you must explicitly set ``enableGenAIFeatures``
+       to ``false``.
 
    * - :ref:`enableDevTools <compass-enable-dev-tools>`
      - Enable Chrome DevTools in |compass-short|.


### PR DESCRIPTION
## DESCRIPTION

Adds missing AI settings to Compass configuration and command-line reference.


## STAGING
* [enableGenAIDocumentPassing Setting](https://deploy-preview-694--docs-compass.netlify.app/settings/config-file/#settings)
* [--enableGenAIFeatures CLI Option](https://deploy-preview-694--docs-compass.netlify.app/settings/command-line-options/#std-option-compass.--enableGenAIFeatures)
* [--enableGenAIDocumentPassing CLI Option](https://deploy-preview-694--docs-compass.netlify.app/settings/command-line-options/#std-option-compass.--enableGenAIDocumentPassing)

## JIRA
[DOCSP-44882](https://jira.mongodb.org/browse/DOCSP-44882)


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)