### PR TITLE
DOCSP-45739 Adds nonce in Auth Req to OIDC connection settings

### DIFF
--- a/source/connect/advanced-connection-options/authentication-connection.txt
+++ b/source/connect/advanced-connection-options/authentication-connection.txt
@@ -133,6 +133,13 @@ Procedure
              settings, |compass-short| uses the same proxy to connect to both 
              the cluster and identity provider.
 
+         * - Send a nonce in the Auth Code Request
+           - Optional. Includes a random nonce as a part of the auth code 
+             request to prevent replay attacks. Enabled by default.
+
+             The nonce is an important security component. This setting should 
+             only be disabled if it is not supported by your OIDC provider.
+
       .. _x509:
 
       X.509

--- a/source/connect/advanced-connection-options/authentication-connection.txt
+++ b/source/connect/advanced-connection-options/authentication-connection.txt
@@ -137,8 +137,8 @@ Procedure
            - Optional. Includes a random nonce as a part of the auth code 
              request to prevent replay attacks. Enabled by default.
 
-             The nonce is an important security component. This setting should 
-             only be disabled if it is not supported by your OIDC provider.
+             The nonce is an important security component. Only disable this
+             setting if it is not supported by your OIDC provider.
 
       .. _x509:
 


### PR DESCRIPTION
## DESCRIPTION
Updates OIDC connection settings to include the new checkbox `Send a nonce in the Auth Code Request`

Note - the description here is based on the UI [description](https://github.com/mongodb-js/compass/pull/6542/files#diff-337de6f5aba02a6de066c13ea23bfdfed45cf6c661c7200293564278eab343ccR184) in the eng [PR](https://github.com/mongodb-js/compass/pull/6542).

## STAGING
https://deploy-preview-700--docs-compass.netlify.app/connect/advanced-connection-options/authentication-connection/#oidc

## JIRA
https://jira.mongodb.org/browse/DOCSP-45739

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)