### PR TITLE
(DOCSP-46530)-Fix-short-title-underline-error

### DIFF
--- a/source/troubleshooting/connection-errors.txt
+++ b/source/troubleshooting/connection-errors.txt
@@ -123,7 +123,7 @@ to view possible solutions:
          http://portquiz.net:27017/.
 
          Atlas IP Access List Does Not Include Your Address
-         ````````````````````````````````````````````````
+         ``````````````````````````````````````````````````
 
          |service| only allows connections to a cluster from addresses
          listed in the project :atlas:`IP access list


### PR DESCRIPTION
## DESCRIPTION
Compass docs have a build error:

WARNING(troubleshooting/connection-errors.txt:72ish): Title underline too short.

Relates to a heading around line 125 with a short line.

## STAGING
https://deploy-preview-710--docs-compass.netlify.app/troubleshooting/connection-errors/#atlas-ip-access-list-does-not-include-your-address
## JIRA
[DOCSP-46530](https://jira.mongodb.org/browse/DOCSP-46530)

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)