### PR TITLE
DOCSP-46836-remove-in-use-encryption-atlas-limitation

### DIFF
--- a/source/connect/advanced-connection-options/in-use-encryption.txt
+++ b/source/connect/advanced-connection-options/in-use-encryption.txt
@@ -12,9 +12,8 @@ In-Use Encryption Connection Tab
    :depth: 1
    :class: singlecol
 
-:guilabel:`In-Use Encryption` is an Enterprise/Atlas only feature. You need a 
-replica set or sharded cluster to use this connection option. Your replica set 
-can be a single node or larger. 
+You need a replica set or sharded cluster to use this connection option.
+Your replica set can be a single node or larger. 
 
 The :guilabel:`In-Use Encryption` connection tab allows you to connect your
 deployments with :v6.0:`Queryable Encryption </core/queryable-encryption/>`.

--- a/source/connect/advanced-connection-options/in-use-encryption.txt
+++ b/source/connect/advanced-connection-options/in-use-encryption.txt
@@ -12,8 +12,8 @@ In-Use Encryption Connection Tab
    :depth: 1
    :class: singlecol
 
-You need a replica set or sharded cluster to use this connection option.
-Your replica set can be a single node or larger. 
+To use this connection option, you need a replica set or sharded
+cluster. Your replica set can be a single node or larger. 
 
 The :guilabel:`In-Use Encryption` connection tab allows you to connect your
 deployments with :v6.0:`Queryable Encryption </core/queryable-encryption/>`.


### PR DESCRIPTION
## DESCRIPTION

Removes limitation that in-use encryption is Atlas/Enterprise only

## STAGING

https://deploy-preview-713--docs-compass.netlify.app/connect/advanced-connection-options/in-use-encryption/

## JIRA

https://jira.mongodb.org/browse/DOCSP-46836

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)