### PR TITLE
DOCSP-45732-add-proxy-setting-compass-config

### DIFF
--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -131,9 +131,7 @@ Settings
        with. For more information on connecting to your deployment with a
        proxy, see :ref:`ssh-connection`.
 
-       You must pass either a URL or a ``DevtoolsProxyOptions`` object as JSON
-       for the ``proxy`` setting. A ``DevtoolsProxyOptions`` object takes the following
-       format: 
+       You must pass either a URL or pass the following format: 
 
        .. code-block::
           

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -131,7 +131,7 @@ Settings
        with. For more information, see :ref:`ssh-connection`.
 
        You must pass either a URL or a DevtoolsProxyOptions object as JSON
-       for the proxy setting. You can also set the proxy setting to an empty
+       for the Proxy setting. You can also set the Proxy setting to an empty
        string. 
 
    * - :ref:`readOnly <compass-read-only>`

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -128,7 +128,8 @@ Settings
 
    * - proxy
      - Allows you to enforce or define a Proxy to connect to your deployment 
-       with. For more information, see :ref:`ssh-connection`.
+       with. For more information on connecting to your deployment with a
+       proxy, see :ref:`ssh-connection`.
 
        You must pass either a URL or a DevtoolsProxyOptions object as JSON
        for the Proxy setting. You can also set the Proxy setting to an empty

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -127,12 +127,12 @@ Settings
        option with the :guilabel:`Edit connection string` toggle. 
 
    * - proxy
-     - Allows you to enforce or define a Proxy to connect to your deployment 
+     - Allows you to enforce or define a ``proxy`` to connect to your deployment 
        with. For more information on connecting to your deployment with a
-       proxy, see :ref:`ssh-connection`.
+       ``proxy``, see :ref:`ssh-connection`.
 
        You must pass either a URL or a ``DevtoolsProxyOptions`` object as JSON
-       for the Proxy setting. A ``DevtoolsProxyOptions`` object takes the following
+       for the ``proxy`` setting. A ``DevtoolsProxyOptions`` object takes the following
        format: 
 
        .. code-block::
@@ -140,13 +140,6 @@ Settings
           {
             proxy: string;
             noProxyHosts: string;
-            useEnvironmentVariableProxies: boolean;
-            sshOptions: {
-              identityKeyFile: string;
-              identityKeyPassphrase: string;
-            };
-            ca: ConnectionOptions['ca'];
-            env: Record<string, string | undefined>;
           }
        
        If you set ``proxy`` to an empty string, no 

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -138,13 +138,15 @@ Settings
        .. code-block::
           
           {
-            proxy?: string;
-            noProxyHosts?: string;
-            useEnvironmentVariableProxies?: boolean;
-            sshOptions?: {
-              identityKeyFile?: string;
-              identityKeyPassphrase?: string;
+            proxy: string;
+            noProxyHosts: string;
+            useEnvironmentVariableProxies: boolean;
+            sshOptions: {
+              identityKeyFile: string;
+              identityKeyPassphrase: string;
             };
+            ca: ConnectionOptions['ca'];
+            env: Record<string, string | undefined>;
           }
        
        If you set ``proxy`` to an empty string, no 

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -136,8 +136,8 @@ Settings
        .. code-block::
           
           {
-            proxy: string;
-            noProxyHosts: string;
+            "proxy": "string",
+            "noProxyHosts": "string"
           }
        
        If you set ``proxy`` to an empty string, no 

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -127,9 +127,9 @@ Settings
        option with the :guilabel:`Edit connection string` toggle. 
 
    * - proxy
-     - Allows you to enforce or define a proxy to connect to your deployment 
-       with. For more information on connecting to your deployment with a
-       proxy, see :ref:`ssh-connection`.
+     - Enables you to specify or enforce the use of a proxy for connecting 
+       to your deployment. For more information on connecting to your 
+       deployment with a proxy, see :ref:`ssh-connection`.
 
        You must pass either a URL or pass the following format: 
 

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -131,9 +131,24 @@ Settings
        with. For more information on connecting to your deployment with a
        proxy, see :ref:`ssh-connection`.
 
-       You must pass either a URL or a DevtoolsProxyOptions object as JSON
-       for the Proxy setting. You can also set the Proxy setting to an empty
-       string. 
+       You must pass either a URL or a ``DevtoolsProxyOptions`` object as JSON
+       for the Proxy setting. A ``DevtoolsProxyOptions`` object takes the following
+       format: 
+
+       .. code-block::
+          
+          {
+            proxy?: string;
+            noProxyHosts?: string;
+            useEnvironmentVariableProxies?: boolean;
+            sshOptions?: {
+              identityKeyFile?: string;
+              identityKeyPassphrase?: string;
+            };
+          }
+       
+       If you set ``proxy`` to an empty string, no 
+       proxy will be used.
 
    * - :ref:`readOnly <compass-read-only>`
      - Prevent users from performing write operations to your MongoDB deployment 

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -126,6 +126,14 @@ Settings
        option but doesn't prevent users from manually enabling the
        option with the :guilabel:`Edit connection string` toggle. 
 
+   * - proxy
+     - Allows you to enforce or define a Proxy to connect to your deployment 
+       with. For more information, see :ref:`ssh-connection`.
+
+       You must pass either a URL or a DevtoolsProxyOptions object as JSON
+       for the proxy setting. You can also set the proxy setting to an empty
+       string. 
+
    * - :ref:`readOnly <compass-read-only>`
      - Prevent users from performing write operations to your MongoDB deployment 
        through |compass-short|.

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -127,11 +127,11 @@ Settings
        option with the :guilabel:`Edit connection string` toggle. 
 
    * - proxy
-     - Enables you to specify or enforce the use of a proxy for connecting 
+     - Enables you to specify or enforce the use of a proxy to connect
        to your deployment. For more information on connecting to your 
        deployment with a proxy, see :ref:`ssh-connection`.
 
-       You must pass either a URL or pass the following format: 
+       You must pass either a URL or the following format: 
 
        .. code-block::
           
@@ -140,8 +140,7 @@ Settings
             "noProxyHosts": "string"
           }
        
-       If you set ``proxy`` to an empty string, no 
-       proxy will be used.
+       If you set ``proxy`` to an empty string, Compass does not use a proxy.
 
    * - :ref:`readOnly <compass-read-only>`
      - Prevent users from performing write operations to your MongoDB deployment 

--- a/source/settings/config-file.txt
+++ b/source/settings/config-file.txt
@@ -127,9 +127,9 @@ Settings
        option with the :guilabel:`Edit connection string` toggle. 
 
    * - proxy
-     - Allows you to enforce or define a ``proxy`` to connect to your deployment 
+     - Allows you to enforce or define a proxy to connect to your deployment 
        with. For more information on connecting to your deployment with a
-       ``proxy``, see :ref:`ssh-connection`.
+       proxy, see :ref:`ssh-connection`.
 
        You must pass either a URL or a ``DevtoolsProxyOptions`` object as JSON
        for the ``proxy`` setting. A ``DevtoolsProxyOptions`` object takes the following


### PR DESCRIPTION
## DESCRIPTION
add a new proxy setting to the [Compass config file docs. ](https://www.mongodb.com/docs/compass/current/settings/config-file/)


## STAGING
https://deploy-preview-716--docs-compass.netlify.app/settings/config-file/

## JIRA
https://jira.mongodb.org/browse/DOCSP-45732

## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)