### PR TITLE
DOCSP-46151-mention-hybrid-search-compass

### DIFF
--- a/source/query/atlas-search.txt
+++ b/source/query/atlas-search.txt
@@ -59,6 +59,9 @@ Steps
 
          If you use the ``$search``, ``$searchMeta``, or ``$vectorSearch`` 
          stage, it must be the first stage in your aggregation pipeline.
+         If you want to combine vector and full-text search in the same 
+         pipeline, you can perform a hybrid search. For more information, 
+         see :ref:`as_hybrid-search`.
 
    .. step:: Run your query
 

--- a/source/query/atlas-search.txt
+++ b/source/query/atlas-search.txt
@@ -59,8 +59,8 @@ Steps
 
          If you use the ``$search``, ``$searchMeta``, or ``$vectorSearch`` 
          stage, it must be the first stage in your aggregation pipeline.
-         If you want to combine vector and full-text search in the same 
-         pipeline, you can perform a hybrid search. For more information, 
+         To combine vector and full-text search in the same pipeline, 
+         perform a hybrid search. For more information, 
          see :ref:`as_hybrid-search`.
 
    .. step:: Run your query


### PR DESCRIPTION
## DESCRIPTION
Add caveat to [Atlas Search Query page](https://www.mongodb.com/docs/compass/current/query/atlas-search/) that search stages must be the first stage in your agg pipeline except when you want to combine both vector and full-text search in the same agg pipeline, in which case you would use hybrid search. 

## STAGING
https://deploy-preview-718--docs-compass.netlify.app/query/atlas-search/#construct-your-query

## JIRA
https://jira.mongodb.org/browse/DOCSP-46151

## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)