### PR TITLE
DOCSP-44435-clarify-compass-buttons

### DIFF
--- a/source/includes/starting-compass-paste-string.rst
+++ b/source/includes/starting-compass-paste-string.rst
@@ -49,8 +49,15 @@
 
    .. step:: Connect to your cluster.
 
-      Click :guilabel:`Save` or :guilabel:`Save & Connect` to navigate to the 
+      Click :guilabel:`Save`, :guilabel:`Connect`, or :guilabel:`Save & Connect` to navigate to the 
       |compass-short| :ref:`Home Page <compass-home-screen>`. 
+
+      The :guilabel:`Save` button saves your connection and closes the modal without
+      yet connecting to your cluster. The :guilabel:`Connect` button allows you to 
+      connect to your cluster without saving your connection string or credentials. 
+
+      The :guilabel:`Save & Connect` button both saves your information and connection-string
+      you to your cluster. 
 
       .. important:: Required Access
         


### PR DESCRIPTION
## DESCRIPTION
Clarify the difference bt the "save", "connect", and "save and connect" buttons when [connecting to your cluster](https://www.mongodb.com/docs/compass/current/connect/#connect) on Compass. 

## STAGING
https://www.mongodb.com/docs/compass/current/connect/#connect

## JIRA
https://jira.mongodb.org/browse/DOCSP-44435

## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)