### PR TITLE
DOCSP-48477-vector-search-visual-tree-unavailable

### DIFF
--- a/source/query-plan.txt
+++ b/source/query-plan.txt
@@ -45,7 +45,8 @@ information on the execution of your query such as:
 .. note:: 
   
   The :guilabel:`Explain Plan` is not available if you are connected
-  to :atlas:`Data Lake </data-lake>`.
+  to :atlas:`Data Lake </data-lake>`. You cannot view 
+  :ref:`vector search<avs-overview>` queries in Visual Tree format.
 .. END-COMPASS-ONLY
 
 Steps 


### PR DESCRIPTION
## DESCRIPTION
Add note to [View Query Performance page](https://www.mongodb.com/docs/compass/current/query-plan/#view-query-performance) that you can't view VS queries as a visual tree. 

## STAGING
https://deploy-preview-733--docs-compass.netlify.app/query-plan/#view-query-performance

## JIRA
https://jira.mongodb.org/browse/DOCSP-48477

## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)