### PR TITLE
DOCSP-48335-fix-404-urls

### DIFF
--- a/source/troubleshooting/connection-errors.txt
+++ b/source/troubleshooting/connection-errors.txt
@@ -127,7 +127,7 @@ to view possible solutions:
 
          |service| only allows connections to a cluster from addresses
          listed in the project :atlas:`IP access list
-         </access-list/>`. Ensure that you have
+         </ip-access-list/>`. Ensure that you have
          access listed your IP address so you can connect to your
          cluster.
 
@@ -214,7 +214,7 @@ Likely Cause
 ~~~~~~~~~~~~
 
 The most common source of this error is a missing |service|
-:atlas:`IP access list </access-list/>` entry for the public IP
+:atlas:`IP access list </ip-access-list/>` entry for the public IP
 address where |compass-short| is running.
 
 Solution
@@ -246,7 +246,7 @@ current IP address, and appends these addresses with
 .. seealso::
 
    For more information on configuring access list entries, see
-   :atlas:`Configure Access List Entries </access-list/>` in the
+   :atlas:`Configure Access List Entries </ip-access-list/>` in the
    |service| documentation.
 
 Not Primary or Secondary is Not Writable

--- a/source/troubleshooting/connection-errors.txt
+++ b/source/troubleshooting/connection-errors.txt
@@ -127,7 +127,7 @@ to view possible solutions:
 
          |service| only allows connections to a cluster from addresses
          listed in the project :atlas:`IP access list
-         </security-accesslist/>`. Ensure that you have
+         </access-list/>`. Ensure that you have
          access listed your IP address so you can connect to your
          cluster.
 
@@ -214,7 +214,7 @@ Likely Cause
 ~~~~~~~~~~~~
 
 The most common source of this error is a missing |service|
-:atlas:`IP access list </security-accesslist/>` entry for the public IP
+:atlas:`IP access list </access-list/>` entry for the public IP
 address where |compass-short| is running.
 
 Solution
@@ -246,7 +246,7 @@ current IP address, and appends these addresses with
 .. seealso::
 
    For more information on configuring access list entries, see
-   :atlas:`Configure Access List Entries </security-accesslist/>` in the
+   :atlas:`Configure Access List Entries </access-list/>` in the
    |service| documentation.
 
 Not Primary or Secondary is Not Writable

--- a/source/troubleshooting/connection-errors.txt
+++ b/source/troubleshooting/connection-errors.txt
@@ -127,7 +127,7 @@ to view possible solutions:
 
          |service| only allows connections to a cluster from addresses
          listed in the project :atlas:`IP access list
-         </ip-access-list/>`. Ensure that you have
+         </security/ip-access-list/>`. Ensure that you have
          access listed your IP address so you can connect to your
          cluster.
 
@@ -214,7 +214,7 @@ Likely Cause
 ~~~~~~~~~~~~
 
 The most common source of this error is a missing |service|
-:atlas:`IP access list </ip-access-list/>` entry for the public IP
+:atlas:`IP access list </security/ip-access-list/>` entry for the public IP
 address where |compass-short| is running.
 
 Solution
@@ -246,7 +246,7 @@ current IP address, and appends these addresses with
 .. seealso::
 
    For more information on configuring access list entries, see
-   :atlas:`Configure Access List Entries </ip-access-list/>` in the
+   :atlas:`Configure Access List Entries </security/ip-access-list/>` in the
    |service| documentation.
 
 Not Primary or Secondary is Not Writable


### PR DESCRIPTION
## DESCRIPTION

Fix 404 link from outdated ref to `/security-accesslist/` to `/security/ip-access-list/`

## STAGING

https://deploy-preview-735--docs-compass.netlify.app/troubleshooting/connection-errors/

## JIRA

https://jira.mongodb.org/browse/DOCSP-48335

## BUILD LOG

https://app.netlify.com/sites/docs-compass/deploys/67e44c216b201b0008884c44

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)