### PR TITLE
compass-snooty-drawer

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -27,7 +27,8 @@ toc_landing_pages = [
     "/schema", 
     "/performance",
     "/create-agg-pipeline", 
-    "/collections"
+    "/collections",
+    "/validation"
 ]
 
 [constants]

--- a/source/validation.txt
+++ b/source/validation.txt
@@ -209,4 +209,3 @@ Learn More
    Generate Validation Rules </generate-validation-rules>
    Add Validation Rules </add-validation-rules>
    Edit Validation Rules </edit-validation-rules>
-   Download Validation Rules </download-validation-rules>


### PR DESCRIPTION
Adds `/validation` to `toc_landing_pages` in `snooty.toml`.