### PR TITLE
DOCSP-48357-incorrect-vs-type

### DIFF
--- a/source/indexes/create-vector-search-index.txt
+++ b/source/indexes/create-vector-search-index.txt
@@ -68,7 +68,7 @@ Steps
            - string
            - Human-readable label that identifies the type of index. The value must 
              be ``vector`` to perform a vector search against the indexed fields. If 
-             omitted, it defaults to ``search``, which only supports full-text search.
+             omitted, it defaults to ``filter``, which only supports full-text search.
 
          * - ``path``
            - string

--- a/source/indexes/create-vector-search-index.txt
+++ b/source/indexes/create-vector-search-index.txt
@@ -54,59 +54,8 @@ Steps
    .. step:: Provide the Atlas Vector Search Index configurations
 
       You must initially provide the following default vector search index 
-      configurations. You can modify the configurations later.
-
-      .. list-table::
-         :header-rows: 1
-         :widths: 20 10 70
-
-         * - Field
-           - Type
-           - Description
-
-         * - ``type``
-           - string
-           - Human-readable label that identifies the type of index. The value must 
-             be ``vector`` to perform a vector search against the indexed fields. If 
-             omitted, it defaults to ``filter``, which only supports full-text search.
-
-         * - ``path``
-           - string
-           - The field name to index.
-        
-         * - ``numDimensions``
-           - int 
-           - The number of vector dimensions, which Atlas Search enforces at index- and 
-             query-time. This value can't be greater than 4096.
-
-         * - ``similarity``
-           - string
-           - The vector similarity function used to search for the top K-nearest neighbors.
-             Select from the following functions:
-
-             .. list-table::
-                :header-rows: 1
-                :widths: 50 50
-
-                * - Function
-                  - Description
-
-                * - ``euclidean``
-                  - A function that measures the distance between ends of vectors. This function 
-                    allows you to measure similarity based on varying dimensions. 
-
-                * - ``cosine``
-                  - A function that measures similarity based on the angle between vectors. This 
-                    function allows you to measure similarity that isn't scaled by magnitude. 
-                    
-                    You can't use zero magnitude vectors with cosine. To measure cosine similarity, 
-                    we recommend that you normalize your vectors and use dotProduct instead.
-
-                * - ``dotProduct``
-                  -  A function that measures similarly to cosine, but takes into account the 
-                     magnitude of the vector. This function allows you to efficiently measure 
-                     similarity based on both angle and magnitude. To use dotProduct, you must 
-                     normalize the vector to unit length at index- and query-time.
+      configurations. You can modify the configurations later. To learn more, 
+      see :ref:`avs-types-vector-search-options`.
 
    .. step:: Click :guilabel:`Create Search Index`
 

--- a/source/indexes/create-vector-search-index.txt
+++ b/source/indexes/create-vector-search-index.txt
@@ -55,8 +55,8 @@ Steps
 
       You must provide all required fields for your vector search index 
       configuration. You can modify the configurations later. 
-      For more information on required fields in vector search 
-      index configurations, see :ref:`avs-types-vector-search-options`.
+      For more information on required fields in vector search index 
+      configurations, see :ref:`avs-types-vector-search-options`.
 
    .. step:: Click :guilabel:`Create Search Index`
 

--- a/source/indexes/create-vector-search-index.txt
+++ b/source/indexes/create-vector-search-index.txt
@@ -53,9 +53,10 @@ Steps
 
    .. step:: Provide the Atlas Vector Search Index configurations
 
-      You must initially provide the following default vector search index 
-      configurations. You can modify the configurations later. To learn more, 
-      see :ref:`avs-types-vector-search-options`.
+      You must provide all required fields for your vector search index 
+      configuration. You can modify the configurations later. 
+      For more information on required fields in vector search 
+      index configurations, see :ref:`avs-types-vector-search-options`.
 
    .. step:: Click :guilabel:`Create Search Index`
 


### PR DESCRIPTION
## DESCRIPTION
Fix incorrect description of VS type in [Compass docs](https://www.mongodb.com/docs/compass/current/indexes/create-vector-search-index/). 

## STAGING
https://deploy-preview-741--docs-compass.netlify.app/indexes/create-vector-search-index/

## JIRA
https://jira.mongodb.org/browse/DOCSP-48357

## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)