### PR TITLE
DOCSP-49449 Adds Compass 1.46.1 release notes

### DIFF
--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -16,7 +16,7 @@ Release Notes
 |compass| 1.46.1
 ----------------
 
-.. *RELEASE DATE*
+*Released April 23, 2025*
 
 New Features:
 

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -13,6 +13,25 @@ Release Notes
    :depth: 1
    :class: twocols
 
+|compass| 1.46.1
+----------------
+
+.. *RELEASE DATE*
+
+New Features:
+
+- Add special handling of vector sub-type (:issue:`COMPASS-8257`)
+
+Bug Fixes:
+
+- Account for pagination in expanded table view (:issue:`COMPASS-9161`)
+- No 0 count for ``bulkDelete`` count (:issue:`COMPASS-8603`)
+- Fix tooltip triggers in indexes plugin (:issue:`COMPASS-8449`)
+- Fix the shortcuts on Windows to be the app name, not executable name (:issue:`COMPASS-8367`)
+
+`Full Changelog available on Github
+<https://github.com/mongodb-js/compass/compare/v1.46.0...v1.46.1>`__
+
 |compass| 1.46.0
 ----------------
 

--- a/source/release-notes.txt
+++ b/source/release-notes.txt
@@ -25,7 +25,7 @@ New Features:
 Bug Fixes:
 
 - Account for pagination in expanded table view (:issue:`COMPASS-9161`)
-- No 0 count for ``bulkDelete`` count (:issue:`COMPASS-8603`)
+- No 0 default for ``bulkDelete`` count (:issue:`COMPASS-8603`)
 - Fix tooltip triggers in indexes plugin (:issue:`COMPASS-8449`)
 - Fix the shortcuts on Windows to be the app name, not executable name (:issue:`COMPASS-8367`)
 


### PR DESCRIPTION
## DESCRIPTION
Adds 1.46.1 release notes

## STAGING
https://deploy-preview-746--docs-compass.netlify.app/release-notes/#compass-1.46.1

## JIRA
https://jira.mongodb.org/browse/DOCSP-49449

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)